### PR TITLE
Fix #15

### DIFF
--- a/nextage_moveit_config/launch/moveit_planning_execution.launch
+++ b/nextage_moveit_config/launch/moveit_planning_execution.launch
@@ -9,4 +9,9 @@
  <include file="$(find nextage_moveit_config)/launch/moveit_rviz.launch"> 
     <arg name="config" value="true"/>
  </include>
+
+ <include file="$(find nextage_moveit_config)/launch/planning_context.launch">
+   <arg name="load_robot_description" value="true"/>
+ </include>
+
 </launch>


### PR DESCRIPTION
Not exactly sure what solves the issue, but as noted [here](https://bitbucket.org/tork-a/iros13/issue/29/nextage-robot-model-rviz-segfault#comment-6752022), `rosparam set robot_description -t NextageOpen.urdf` seems to be a key and that's done in the newly included `.launch` file.
