### PR TITLE
Revert adding roslint that is not available in Groovy

### DIFF
--- a/nextage_ros_bridge/CMakeLists.txt
+++ b/nextage_ros_bridge/CMakeLists.txt
@@ -4,7 +4,7 @@ project(nextage_ros_bridge)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS hironx_ros_bridge nextage_description roslint)
+find_package(catkin REQUIRED COMPONENTS hironx_ros_bridge nextage_description)
 
 catkin_python_setup()
 
@@ -21,8 +21,6 @@ catkin_package(
 include_directories(
   ${catkin_INCLUDE_DIRS}
 )
-
-roslint_python()
 
 ###################################################
 ## Generate Roobt Models and Configuration Files ##

--- a/nextage_ros_bridge/package.xml
+++ b/nextage_ros_bridge/package.xml
@@ -17,7 +17,6 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>hironx_ros_bridge</build_depend>
   <build_depend>nextage_description</build_depend>
-  <build_depend>roslint</build_depend>
   
   <run_depend>hironx_ros_bridge</run_depend>
   <run_depend>nextage_description</run_depend>


### PR DESCRIPTION
This is against `groovy-devel` branch (default branch now is `hydro-devel`).
