### PR TITLE
Cherry-picking run_depend addition from groovy-devel

### DIFF
--- a/nextage_moveit_config/package.xml
+++ b/nextage_moveit_config/package.xml
@@ -16,14 +16,12 @@
   <url type="bugtracker">https://github.com/tork-a/rtmros_nextage/issues</url>
   <url type="repository">https://github.com/tork-a/rtmros_nextage</url>
 
+  <buildtool_depend>catkin</buildtool_depend>
   <build_depend>nextage_description</build_depend>
-
-  <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>moveit_planners</run_depend>
   <run_depend>moveit_ros</run_depend>
-  <run_depend>pr2_moveit_plugins</run_depend>
+  <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>nextage_description</run_depend>
-
-  <buildtool_depend>catkin</buildtool_depend>
+  <run_depend>pr2_moveit_plugins</run_depend>
   
 </package>

--- a/nextage_moveit_config/package.xml
+++ b/nextage_moveit_config/package.xml
@@ -16,8 +16,12 @@
   <url type="bugtracker">https://github.com/tork-a/rtmros_nextage/issues</url>
   <url type="repository">https://github.com/tork-a/rtmros_nextage</url>
 
-  <run_depend>moveit_ros_move_group</run_depend>
   <build_depend>nextage_description</build_depend>
+
+  <run_depend>moveit_ros_move_group</run_depend>
+  <run_depend>moveit_planners</run_depend>
+  <run_depend>moveit_ros</run_depend>
+  <run_depend>pr2_moveit_plugins</run_depend>
   <run_depend>nextage_description</run_depend>
 
   <buildtool_depend>catkin</buildtool_depend>


### PR DESCRIPTION
@k-okada Sorry I haven't been clear that the default branch is `hydro-devel` (since `roslint` isn't available in Groovy).
