### PR TITLE
(nextage_client.py) Remove ServoController. NXO by default does not ship with servo-controlled hand.

### DIFF
--- a/nextage_ros_bridge/src/nextage_ros_bridge/nextage_client.py
+++ b/nextage_ros_bridge/src/nextage_ros_bridge/nextage_client.py
@@ -165,7 +165,7 @@ class NextageClient(HIRONX, object):
             ['fk', "ForwardKinematics"],
             ['el', "SoftErrorLimiter"],
             # ['co', "CollisionDetector"],
-            ['sc', "ServoController"],
+            # ['sc', "ServoController"],
             ['log', "DataLogger"]
             ]
 


### PR DESCRIPTION
Got an idea at https://github.com/start-jsk/rtmros_hironx/issues/161
