### PR TITLE
(nextage_ros_bridge_real.launch) Init commit. Fix #79

### DIFF
--- a/nextage_ros_bridge/launch/nextage_ros_bridge_real.launch
+++ b/nextage_ros_bridge/launch/nextage_ros_bridge_real.launch
@@ -1,0 +1,17 @@
+<launch>
+  <arg name="CONF_FILE_COLLISIONDETECT" default="$(find hironx_ros_bridge)/conf/hironx_realrobot_fixedpath.conf" />
+  <arg name="corbaport" default="15005" />
+  <arg name="MODEL_FILE" default="/opt/jsk/etc/HIRONX/model/main.wrl" /> <!-- This shouldn't be changed unless you know what you're doing; this is the location of vrml file internal to the robot (on QNX OS). -->
+  <arg name="nameserver" default="nextage" /> <!-- Host name of the QNX. -->
+  <arg name="USE_SERVOCONTROLLER" default="false" />
+
+  <env name="RTCTREE_NAMESERVERS" value="$(arg nameserver):$(arg corbaport)" />
+
+  <include file="$(find hironx_ros_bridge)/launch/hironx_ros_bridge_real.launch" >
+    <arg name="CONF_FILE_COLLISIONDETECT" value="$(arg CONF_FILE_COLLISIONDETECT)" />
+    <arg name="corbaport" value="$(arg corbaport)" />
+    <arg name="MODEL_FILE" value="$(arg MODEL_FILE)" />
+    <arg name="nameserver" value="$(arg nameserver)" />
+    <arg name="USE_SERVOCONTROLLER" value="$(arg USE_SERVOCONTROLLER)" />
+  </include>
+</launch>


### PR DESCRIPTION
Requires https://github.com/start-jsk/rtmros_hironx/pull/166 to be merged.

I'm not 100% confident if this is the best optimal solution to #79 -- This new `launch` file is a mere copy of [hironx_ros_bridge_real.launch](https://github.com/130s/rtmros_hironx/blob/baf2989493887349b7c66f660d006d4b896696f7/hironx_ros_bridge/launch/hironx_ros_bridge_real.launch) and basically very redundant. I could do is to let NXO users run `hironx_ros_bridge_real.launch`. But I'm afraid it's confusing for them to run `roslaunch hironx_ros_bridge` when they think they are using `Nextage Open` without even knowing there's a similar robot called `Hironx`. So this redundancy should definitely keep launch files usability higher.

Also, in this way NXO users can launch with their own setting.
