### PR TITLE
(moveit_rviz.launch) Enable natto-view for NXO package on RViz.

### DIFF
--- a/nextage_moveit_config/launch/moveit_rviz.launch
+++ b/nextage_moveit_config/launch/moveit_rviz.launch
@@ -6,7 +6,11 @@
 
   <arg name="config" default="false" />
   <arg unless="$(arg config)" name="command_args" value="" />
-  <arg     if="$(arg config)" name="command_args" value="-d $(find nextage_moveit_config)/launch/moveit.rviz" />
+
+  <!-- Enabling "natto-view". If it's too smelly or sticky for you, comment in moveit.rviz line.
+       Note that for natto-view, hironx_moveit_config package, not nextage, is referred to avoid unnecessary redundancy. -->
+<!--  <arg     if="$(arg config)" name="command_args" value="-d $(find nextage_moveit_config)/launch/moveit.rviz" /> --> 
+  <arg     if="$(arg config)" name="command_args" value="-d $(find hironx_moveit_config)/launch/moveit_viewnatto.rviz" /> 
   
   <node name="$(anon rviz)" launch-prefix="$(arg launch_prefix)" pkg="rviz" type="rviz" respawn="false"
 	args="$(arg command_args)" output="screen">
@@ -14,3 +18,4 @@
   </node>
 
 </launch>
+


### PR DESCRIPTION
Requires https://github.com/tork-a/rtmros_nextage/pull/81 to be merged (or, need a .launch file that enables collision detection).
