### PR TITLE
(moveit_rviz) Correct fixed frame. 

### DIFF
--- a/nextage_moveit_config/launch/moveit_rviz.launch
+++ b/nextage_moveit_config/launch/moveit_rviz.launch
@@ -1,16 +1,15 @@
 <launch>
-
   <arg name="debug" default="false" />
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
   <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
 
+  <arg name="RVIZ_FIXEDFRAME" default="WAIST_Link" />
   <arg name="config" default="false" />
   <arg unless="$(arg config)" name="command_args" value="" />
 
   <!-- Enabling "natto-view". If it's too smelly or sticky for you, comment in moveit.rviz line.
        Note that for natto-view, hironx_moveit_config package, not nextage, is referred to avoid unnecessary redundancy. -->
-<!--  <arg     if="$(arg config)" name="command_args" value="-d $(find nextage_moveit_config)/launch/moveit.rviz" /> --> 
-  <arg     if="$(arg config)" name="command_args" value="-d $(find hironx_moveit_config)/launch/moveit_viewnatto.rviz" /> 
+  <arg if="$(arg config)" name="command_args" value="--fixed-frame $(arg RVIZ_FIXEDFRAME) -d $(find hironx_moveit_config)/launch/moveit_viewnatto.rviz" /> 
   
   <node name="$(anon rviz)" launch-prefix="$(arg launch_prefix)" pkg="rviz" type="rviz" respawn="false"
 	args="$(arg command_args)" output="screen">


### PR DESCRIPTION
With [this commit](https://github.com/tork-a/rtmros_nextage/commit/ed83e8a01b86a68138309d22cb920e4de941d73a#diff-e4da40d57291cf6466a68db80dadc721), moveit launch file in this package refers `rviz` config in hironx package, where the fixed frame on RViz is `WAIST`, not `WAIST_Link` that's default in Nextage. 

At least that misconfiguration disables `Interactive Marker`. This PReq re-enables it to appear.
