### PR TITLE
Adjust to the spec change of DIO. Add a customized read digital input method.

### DIFF
--- a/nextage_ros_bridge/src/nextage_ros_bridge/command/gripper_command.py
+++ b/nextage_ros_bridge/src/nextage_ros_bridge/command/gripper_command.py
@@ -61,6 +61,8 @@ class GripperCommand(AbsractHandCommand):
         '''
         self._DIO_VALVE_L_1 = self._DIO_25
         self._DIO_VALVE_L_2 = self._DIO_26
+        self._DIO_VALVE_R_1 = self._DIO_20
+        self._DIO_VALVE_R_2 = self._DIO_21
 
     def execute(self, operation):
         '''
@@ -68,11 +70,20 @@ class GripperCommand(AbsractHandCommand):
         '''
         dout = []
         #TODO: Implement right arm too!
-        mask = [self._DIO_VALVE_L_1, self._DIO_VALVE_L_2]
+        mask_l = [self._DIO_VALVE_L_1, self._DIO_VALVE_L_2]
+        mask_r = [self._DIO_VALVE_R_1, self._DIO_VALVE_R_2]
         if self.GRIPPER_CLOSE == operation:
             if self._hands.HAND_L == self._hand:
                 dout = [self._DIO_VALVE_L_1]
-        elif self.GRIPPER_OPEN == operation:
-            if self._hands.HAND_L == self._hand:
-                dout = [self._DIO_VALVE_L_2]
+
+            elif self._hands.HAND_R == self._hand:
+                dout = [self._DIO_VALVE_R_1]
+#        elif self.GRIPPER_OPEN == operation:
+#            if self._hands.HAND_L == self._hand:
+#                dout = [self._DIO_VALVE_L_2]
+        mask = None 
+        if self._hands.HAND_L == self._hand:
+            mask = mask_l
+        elif self._hands.HAND_R == self._hand:
+            mask = mask_r
         return self._hands._dio_writer(dout, mask)

--- a/nextage_ros_bridge/src/nextage_ros_bridge/command/gripper_command.py
+++ b/nextage_ros_bridge/src/nextage_ros_bridge/command/gripper_command.py
@@ -69,7 +69,6 @@ class GripperCommand(AbsractHandCommand):
         @see abs_hand_command.AbsractHandCommand.execute
         '''
         dout = []
-        #TODO: Implement right arm too!
         mask_l = [self._DIO_VALVE_L_1, self._DIO_VALVE_L_2]
         mask_r = [self._DIO_VALVE_R_1, self._DIO_VALVE_R_2]
         if self.GRIPPER_CLOSE == operation:

--- a/nextage_ros_bridge/src/nextage_ros_bridge/nextage_client.py
+++ b/nextage_ros_bridge/src/nextage_ros_bridge/nextage_client.py
@@ -178,7 +178,7 @@ class NextageClient(HIRONX, object):
             init_pose_type = HIRONX.INITPOS_TYPE_EVEN
         return HIRONX.goInitial(self, tm, wait, init_pose_type)
 
-    def printDin(self, ports, dumpFlag=True):
+    def readDigitalInputGroup(self, ports, dumpFlag=True):
         '''
         Print the currently set values of digital input registry. Print output order is tailored 
         for the hands' functional group; DIO spec that is disloseable as of 7/17/2014 is:
@@ -220,18 +220,19 @@ class NextageClient(HIRONX, object):
         @type ports: int or [int].
         @param dumpFlag: Print each pin if True.
         @param ports: A port number or a list of port numbers in D-in registry.
+        @rtype: [(int, int)]
+        @return: List of tuples of port and din value. If the arg ports was an int value, 
+                 this could be a list with single tuple in it.
         '''
         if isinstance(ports, int):
             ports = [ports];
             pass;
         #din = self.rh_svc.readDigitalInput()[1];
         ## rh_svc.readDigitalInput() returns tuple, of which 1st element is not needed here.
-        boolret, din = self.readDigitalInput(retRaw=True);
+        din = self.readDigitalInput();
         resAry=[];
         for port in ports:
-            byteIdx = port/8;
-            bitIdx = port%8;
-            res = (ord(din[byteIdx]) >> bitIdx) & 1;
+            res = din[port]
             if (dumpFlag): print("DI%02d is %d"%(port+1,res));
             resAry.append((port, res));
             pass;

--- a/nextage_ros_bridge/src/nextage_ros_bridge/nextage_client.py
+++ b/nextage_ros_bridge/src/nextage_ros_bridge/nextage_client.py
@@ -177,3 +177,62 @@ class NextageClient(HIRONX, object):
             # Set the pose where eefs level with the tabletop by default.
             init_pose_type = HIRONX.INITPOS_TYPE_EVEN
         return HIRONX.goInitial(self, tm, wait, init_pose_type)
+
+    def printDin(self, ports, dumpFlag=True):
+        '''
+        Print the currently set values of digital input registry. Print output order is tailored 
+        for the hands' functional group; DIO spec that is disloseable as of 7/17/2014 is:
+
+             Left hand: 
+                  DI26: Tool changer attached or not.
+                  DI22, 23: Fingers.
+                  DI24, 25: Compliance.
+
+             Right hand: 
+                  DI21: Tool changer attached or not.
+                  DI17, 18: Fingers.
+                  DI19, 20: Compliance.
+
+        Example output, for the right hand: 
+
+            No hand attached:
+
+                In [1]: robot.printDin([20, 16, 17, 18, 19])
+                DI21 is 0
+                DI17 is 0
+                DI18 is 0
+                DI19 is 0
+                DI20 is 0
+                Out[1]: [(20, 0), (16, 0), (17, 0), (18, 0), (19, 0)]
+    
+            Hand attached, fingers closed:
+
+                In [1]: robot.printDin([20, 16, 17, 18, 19])
+                DI21 is 1
+                DI17 is 1
+                DI18 is 0
+                DI19 is 0
+                DI20 is 0
+                Out[1]: [(20, 0), (16, 0), (17, 0), (18, 0), (19, 0)]
+    
+        @author: Koichi Nagashima
+        @since: 0.2.16
+        @type ports: int or [int].
+        @param dumpFlag: Print each pin if True.
+        @param ports: A port number or a list of port numbers in D-in registry.
+        '''
+        if isinstance(ports, int):
+            ports = [ports];
+            pass;
+        #din = self.rh_svc.readDigitalInput()[1];
+        ## rh_svc.readDigitalInput() returns tuple, of which 1st element is not needed here.
+        boolret, din = self.readDigitalInput(retRaw=True);
+        resAry=[];
+        for port in ports:
+            byteIdx = port/8;
+            bitIdx = port%8;
+            res = (ord(din[byteIdx]) >> bitIdx) & 1;
+            if (dumpFlag): print("DI%02d is %d"%(port+1,res));
+            resAry.append((port, res));
+            pass;
+        return resAry;

--- a/nextage_ros_bridge/src/nextage_ros_bridge/nextage_client.py
+++ b/nextage_ros_bridge/src/nextage_ros_bridge/nextage_client.py
@@ -57,6 +57,12 @@ class NextageClient(HIRONX, object):
                [0, 0, 0, 0],
                [0, 0, 0, 0]]
 
+    # Default digital input groups defined by manufacturer, Kawada, as of
+    # July 2014. This may change per the robot in the future and in then
+    # need modified. See also readDinGroup method.
+    _DI_PORTS_L = [25, 21, 22, 23, 24]
+    _DI_PORTS_R = [20, 16, 17, 18, 19]
+
     def __init__(self):
         '''
         Do not get confused that there is also a method called
@@ -178,7 +184,7 @@ class NextageClient(HIRONX, object):
             init_pose_type = HIRONX.INITPOS_TYPE_EVEN
         return HIRONX.goInitial(self, tm, wait, init_pose_type)
 
-    def readDigitalInputGroup(self, ports, dumpFlag=True):
+    def readDinGroup(self, ports, dumpFlag=True):
         '''
         Print the currently set values of digital input registry. Print output order is tailored 
         for the hands' functional group; DIO spec that is disloseable as of 7/17/2014 is:
@@ -237,3 +243,10 @@ class NextageClient(HIRONX, object):
             resAry.append((port, res));
             pass;
         return resAry;
+
+    def readDinGroupL(self, dumpFlag=True):
+        return self.readDinGroup(self._DI_PORTS_L, dumpFlag)
+
+    def readDinGroupR(self, dumpFlag=True):
+        return self.readDinGroup(self._DI_PORTS_R, dumpFlag)
+


### PR DESCRIPTION
DIO spec has changed on manufacturer's end. 

Since they say this spec is likely to stay longer, we can create a `standard` hand class with the DIO spec as of today, and set aside `Iros13` setting as just a sample.
