### PR TITLE
(moveit_config) Default speed needs to be moderately slow.

### DIFF
--- a/nextage_moveit_config/config/joint_limits.yaml
+++ b/nextage_moveit_config/config/joint_limits.yaml
@@ -1,62 +1,62 @@
 joint_limits:
   RARM_JOINT0:
     has_velocity_limits: true
-    max_velocity: 6.0
+    max_velocity: 1.0
     has_acceleration_limits: true
-    max_acceleration: 6.5
+    max_acceleration: 1.5
   RARM_JOINT1:
     has_velocity_limits: true
-    max_velocity: 6.0
+    max_velocity: 1.0
     has_acceleration_limits: true
-    max_acceleration: 6.5
+    max_acceleration: 1.5
   RARM_JOINT2:
     has_velocity_limits: true
-    max_velocity: 6.0
+    max_velocity: 1.0
     has_acceleration_limits: true
-    max_acceleration: 6.5
+    max_acceleration: 1.5
   RARM_JOINT3:
     has_velocity_limits: true
-    max_velocity: 6.0
+    max_velocity: 1.0
     has_acceleration_limits: true
-    max_acceleration: 6.5
+    max_acceleration: 1.5
   RARM_JOINT4:
     has_velocity_limits: true
-    max_velocity: 6.0
+    max_velocity: 1.0
     has_acceleration_limits: true
-    max_acceleration: 6.5
+    max_acceleration: 1.5
   RARM_JOINT5:
     has_velocity_limits: true
-    max_velocity: 6.0
+    max_velocity: 1.0
     has_acceleration_limits: true
-    max_acceleration: 6.5
+    max_acceleration: 1.5
   LARM_JOINT0:
     has_velocity_limits: true
-    max_velocity: 6.0
+    max_velocity: 1.0
     has_acceleration_limits: true
-    max_acceleration: 6.5
+    max_acceleration: 1.5
   LARM_JOINT1:
     has_velocity_limits: true
-    max_velocity: 6.0
+    max_velocity: 1.0
     has_acceleration_limits: true
-    max_acceleration: 6.5
+    max_acceleration: 1.5
   LARM_JOINT2:
     has_velocity_limits: true
-    max_velocity: 6.0
+    max_velocity: 1.0
     has_acceleration_limits: true
-    max_acceleration: 6.5
+    max_acceleration: 1.5
   LARM_JOINT3:
     has_velocity_limits: true
-    max_velocity: 6.0
+    max_velocity: 1.0
     has_acceleration_limits: true
-    max_acceleration: 6.5
+    max_acceleration: 1.5
   LARM_JOINT4:
     has_velocity_limits: true
-    max_velocity: 6.0
+    max_velocity: 1.0
     has_acceleration_limits: true
-    max_acceleration: 6.5
+    max_acceleration: 1.5
   LARM_JOINT5:
     has_velocity_limits: true
-    max_velocity: 6.0
+    max_velocity: 1.0
     has_acceleration_limits: true
-    max_acceleration: 6.5
+    max_acceleration: 1.5
 


### PR DESCRIPTION
[Values currently set are very fast](https://github.com/tork-a/rtmros_nextage/commit/bbf7d31e285223ac216f5d11da8ca4249947ebaa#diff-ff83b48fa6274dda265e036bf5a75a9e) because of a special request at the time of an event. This PReq reverts it back to moderate speed.
