### PR TITLE
changelog for newer version. Bump minor version (see #91).

### DIFF
--- a/nextage_description/CHANGELOG.rst
+++ b/nextage_description/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package nextage_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Remove WAIST_Link to use only WAIST (Fix `#97 <https://github.com/tork-a/rtmros_nextage/issues/97>`_).
+* Contributors: Isaac IY Saito
+
 0.2.18 (2014-08-01)
 -------------------
 

--- a/nextage_description/package.xml
+++ b/nextage_description/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>nextage_description</name>
-  <version>0.2.18</version>
+  <version>0.4.0</version>
   <description>As a part of rtmros_nextage package that is a ROS interface for <a href = "http://nextage.kawada.jp/en/">Nextage</a> dual-armed robot from Kawada Robotics Inc, this package provides its 3D model that can be used in simulation and <a href = "http://ros.org/wiki/moveit">MoveIt!</a>-based motion planning tasks.
   </description>
   <maintainer email="k-okada@jsk.t.u-tokyo.ac.jp">Kei Okada</maintainer>

--- a/nextage_moveit_config/CHANGELOG.rst
+++ b/nextage_moveit_config/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package nextage_moveit_config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Remove WAIST_Link to use only WAIST (Fix `#97 <https://github.com/tork-a/rtmros_nextage/issues/97>`_).
+* Contributors: Isaac IY Saito
+
 0.2.18 (2014-08-01)
 -------------------
 * (moveit_config) Default speed now moderately slow.

--- a/nextage_moveit_config/package.xml
+++ b/nextage_moveit_config/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>nextage_moveit_config</name>
-  <version>0.2.18</version>
+  <version>0.4.0</version>
   <description>An automatically generated package with all the configuration and launch files for using the NextageOpen with the MoveIt Motion Planning Framework.
   </description>
   <maintainer email="k-okada@jsk.t.u-tokyo.ac.jp">Kei Okada</maintainer>

--- a/nextage_ros_bridge/CHANGELOG.rst
+++ b/nextage_ros_bridge/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog for package nextage_ros_bridge
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Remove WAIST_Link to use only WAIST (Fix "Either Interactive Marker or Natto-view appears, not together." `#97 <https://github.com/tork-a/rtmros_nextage/issues/97>`_).
+* DIO Accessor:
+
+  * Ignore tests for hand lighting when on simulation (Fix `#94 <https://github.com/tork-a/rtmros_nextage/issues/94>`_)
+  * (DIO files) Minor improvement to api doc.
+* Contributors: Isaac IY Saito
+
 0.2.18 (2014-08-01)
 -------------------
 

--- a/nextage_ros_bridge/package.xml
+++ b/nextage_ros_bridge/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>nextage_ros_bridge</name>
-  <version>0.2.18</version>
+  <version>0.4.0</version>
   <description>The nextage_ros_bridge package is a main ROS interface for developers and users of <a href = "http://nextage.kawada.jp/en/">Nextage</a> dual-armed robot from Kawada Robotics Inc. Developers can build their own application that takes control over Nextage via this package. Interface for both ROS and <a href = "http://openrtm.org/">OpenRTM</a> is provided.
   </description>
 

--- a/rtmros_nextage/CHANGELOG.rst
+++ b/rtmros_nextage/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog for package rtmros_nextage
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Remove WAIST_Link to use only WAIST (Fix "Either Interactive Marker or Natto-view appears, not together." `#97 <https://github.com/tork-a/rtmros_nextage/issues/97>`_).
+* DIO Accessor:
+
+  * Ignore tests for hand lighting when on simulation (Fix `#94 <https://github.com/tork-a/rtmros_nextage/issues/94>`_)
+  * (DIO files) Minor improvement to api doc.
+* Contributors: Isaac IY Saito
+
 0.2.18 (2014-08-01)
 -------------------
 * (moveit_config) Default speed now moderately slow.

--- a/rtmros_nextage/package.xml
+++ b/rtmros_nextage/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>rtmros_nextage</name>
-  <version>0.2.18</version>
+  <version>0.4.0</version>
   <description>The rtmros_nextage package is a ROS interface for <a href = "http://nextage.kawada.jp/en/">Nextage</a> dual-armed robot from Kawada Robotics Inc.
   </description>
   <maintainer email="iisaito@opensource-robotics.tokyo.jp">Isaac Isao Saito</maintainer>


### PR DESCRIPTION
Version numbers in `package.xml` remain `0.4."0"` -- they are expected to be incremented by `catkin_prepare_release` later.
