### PR TITLE
Remove non-existent eef groups.

### DIFF
--- a/nextage_moveit_config/config/NextageOpen.srdf
+++ b/nextage_moveit_config/config/NextageOpen.srdf
@@ -55,8 +55,10 @@
         <joint name="RARM_JOINT5" value="0.055851" />
     </group_state>
     <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
-    <end_effector name="right_eef" parent_link="RARM_JOINT5_Link" group="right_gripper" parent_group="right_arm" />
-    <end_effector name="left_eef" parent_link="LARM_JOINT5_Link" group="left_gripper" parent_group="left_arm" />
+    <!-- Jan, 2015: EEF groups are not configured -->
+    <!--  <end_effector name="right_eef" parent_link="RARM_JOINT5_Link" group="right_gripper" parent_group="right_arm" />
+    <end_effector name="left_eef" parent_link="LARM_JOINT5_Link" group="left_gripper" parent_group="left_arm" /> 
+    -->
     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
     <virtual_joint name="virtual_joint" type="fixed" parent_frame="odom" child_link="WAIST" />
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->


### PR DESCRIPTION
This should eliminate the following errors that are confusing.

```
[ERROR] [1421313816.849392873]: End effector 'right_eef' specified for group 'right_gripper', but that group is not known
[ERROR] [1421313816.849547103]: End effector 'left_eef' specified for group 'left_gripper', but that group is not known
```
