### PR TITLE
[test_handlight.py] fix to pass the test, handlight

### DIFF
--- a/nextage_ros_bridge/test/test_handlight.py
+++ b/nextage_ros_bridge/test/test_handlight.py
@@ -79,7 +79,7 @@ class TestNxoHandlight(unittest.TestCase):
     def test_handlight_r_02(self):
         if self._robot.simulation_mode:
             result = self._robot._hands.handlight_r(is_on=False)
-            self.assertFalse(result)
+            self.assertTrue(result)
         else:
             result = self._robot._hands.handlight_r(is_on=True)
             self.assertTrue(result)
@@ -87,7 +87,7 @@ class TestNxoHandlight(unittest.TestCase):
     def test_handlight_r_04(self):
         if self._robot.simulation_mode:
             result = self._robot_04.handlight_r(is_on=False)
-            self.assertFalse(result)
+            self.assertTrue(result)
         else:
             result = self._robot_04.handlight_r(is_on=True)
             self.assertTrue(result)
@@ -103,7 +103,7 @@ class TestNxoHandlight(unittest.TestCase):
     def test_handlight_l_04(self):
         if self._robot.simulation_mode:
             result = self._robot_04.handlight_l(is_on=False)
-            self.assertFalse(result)
+            self.assertTrue(result)
         else:
             result = self._robot_04.handlight_l(is_on=True)
             self.assertTrue(result)


### PR DESCRIPTION
- writeDigitalOutput always returns True in simulation https://github.com/fkanehiro/hrpsys-base/blob/master/python/hrpsys_config.py#L1284
- lhand alywas returns False https://github.com/tork-a/rtmros_nextage/blob/hydro-devel/nextage_ros_bridge/src/nextage_ros_bridge/command/handlight_command.py#L101

cf. https://github.com/fkanehiro/hrpsys-base/issues/404
