### PR TITLE
Add dependency on ueye_cam.

### DIFF
--- a/nextage_ros_bridge/package.xml
+++ b/nextage_ros_bridge/package.xml
@@ -23,6 +23,7 @@
   
   <run_depend version_gte="1.0.17">hironx_ros_bridge</run_depend>
   <run_depend>nextage_description</run_depend>
+  <run_depend>ueye_cam</run_depend>
 
   <export/>
 </package>


### PR DESCRIPTION
https://github.com/tork-a/rtmros_nextage/pull/162 implicitly (but obviously) depends on `ueye_cam`.
