### PR TITLE
[nextage_ros_bridge] Fix typo and enable to change camera

### DIFF
--- a/nextage_ros_bridge/launch/ar.launch
+++ b/nextage_ros_bridge/launch/ar.launch
@@ -3,7 +3,7 @@
     <arg name="max_new_marker_error" default="0.08" />
     <arg name="max_track_error" default="0.2" />
     <arg name="cam_image_topic" default="/right_hand_ueye/image_raw" />
-    <arg name="cam_info_topic" default="/right_hand_yeye/camera_info" />
+    <arg name="cam_info_topic" default="/right_hand_ueye/camera_info" />
     <arg name="output_frame" default="/camera" />
 
     <node name="ar_track_alvar" pkg="ar_track_alvar" type="individualMarkersNoKinect"

--- a/nextage_ros_bridge/launch/ar.launch
+++ b/nextage_ros_bridge/launch/ar.launch
@@ -2,8 +2,9 @@
     <arg name="marker_size" default="5.5" />
     <arg name="max_new_marker_error" default="0.08" />
     <arg name="max_track_error" default="0.2" />
-    <arg name="cam_image_topic" default="/right_hand_ueye/image_raw" />
-    <arg name="cam_info_topic" default="/right_hand_ueye/camera_info" />
+    <arg name="cam_ns" default="right_hand_ueye" />
+    <arg name="cam_image_topic" default="/$(arg cam_ns)/image_raw" />
+    <arg name="cam_info_topic" default="/$(arg cam_ns)/camera_info" />
     <arg name="output_frame" default="/camera" />
 
     <node name="ar_track_alvar" pkg="ar_track_alvar" type="individualMarkersNoKinect"


### PR DESCRIPTION
This PR is only to fix and refine `ar.launch`.
- Fix typo "yeye" to "ueye" https://github.com/tork-a/rtmros_nextage/commit/f286c118cfc682a13f13031e2a16163c2d2c79c7#diff-02dc9ac7c4a16820cdbccf54e790d1b6R6
- Enable to change hand camera for `ar_track_alvar` node.
