### PR TITLE
[travis] Utilize catkin_test_results for a better test result print

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
     - CATKIN_WS=~/catkin_ws
     - CATKIN_WS_SRC=${CATKIN_WS}/src
   matrix:
-    - CI_ROS_DISTRO="indigo"
-    #- CI_ROS_DISTRO="jade"
+    - CI_ROS_DISTRO="indigo" DEB_REPOSITORY=http://packages.ros.org/ros/ubuntu
+    - CI_ROS_DISTRO="indigo" DEB_REPOSITORY=http://packages.ros.org/ros-shadow-fixed/ubuntu
 notifications:
   email:
     recipients:
@@ -20,7 +20,7 @@ notifications:
     on_success: always #[always|never|change] # default: change
     on_failure: always #[always|never|change] # default: always
 install:
-  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
+  - sudo sh -c "echo \"deb ${DEB_REPOSITORY} `lsb_release -cs` main\" > /etc/apt/sources.list.d/ros-latest.list"
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update -qq
   - sudo apt-get install -qq -y python-rosdep python-catkin-tools
@@ -42,3 +42,5 @@ script:
   - catkin build --limit-status-rate 0.1 --no-notify --make-args tests
   # Run tests
   - catkin run_tests
+  # check test (this only works from indigo onward)
+  - catkin_test_results build

--- a/nextage_ros_bridge/CMakeLists.txt
+++ b/nextage_ros_bridge/CMakeLists.txt
@@ -4,7 +4,7 @@ project(nextage_ros_bridge)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS hironx_ros_bridge nextage_description roslint)
+find_package(catkin REQUIRED COMPONENTS hironx_ros_bridge nextage_description roslint rostest)
 
 catkin_python_setup()
 
@@ -130,3 +130,5 @@ install(CODE "
 install(DIRECTORY test
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
   USE_SOURCE_PERMISSIONS)
+
+add_rostest(test/nxo.test)


### PR DESCRIPTION
Enabling shadow-fixed repo on the CI test has an advantage (see https://github.com/start-jsk/denso/pull/67/files#r44364033).
