### PR TITLE
clean up nxo.test to utilize nextage_startup.launch

### DIFF
--- a/nextage_moveit_config/CMakeLists.txt
+++ b/nextage_moveit_config/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(nextage_moveit_config)
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED rostest)
 
 catkin_package()
 
@@ -17,3 +17,5 @@ endif ("${SETUP_DIRECTORY}" STREQUAL "")
 set(PROJECT_SOURCE_DIR ${PROJECT_SOURCE_DIR})
 configure_file(${PROJECT_SOURCE_DIR}/NextageROS.desktop.in ${SETUP_DIRECTORY}/NextageROS.desktop)
 add_custom_target(desktop ALL DEPENDS ${PROJECT_SOURCE_DIR}/NextageROS.desktop.in)
+
+add_rostest(test/nxo_moveit.test)

--- a/nextage_moveit_config/package.xml
+++ b/nextage_moveit_config/package.xml
@@ -17,12 +17,15 @@
   <url type="repository">https://github.com/tork-a/rtmros_nextage</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>nextage_description</build_depend>
+  <build_depend>hironx_moveit_config</build_depend>
+  <build_depend>nextage_ros_bridge</build_depend>
+  <build_depend>rostest</build_depend>
+
   <run_depend>hironx_moveit_config</run_depend>
   <run_depend>moveit_planners</run_depend>
   <run_depend>moveit_ros</run_depend>
   <run_depend>moveit_ros_move_group</run_depend>
-  <run_depend>nextage_description</run_depend>
+  <run_depend>nextage_ros_bridge</run_depend>
   <run_depend>pr2_moveit_plugins</run_depend>
   
 </package>

--- a/nextage_moveit_config/test/nxo_moveit.test
+++ b/nextage_moveit_config/test/nxo_moveit.test
@@ -1,0 +1,41 @@
+<launch>
+  <arg name="corbaport" default="2809" />
+  <arg name="GUI" default='false' />
+  <arg name="ROBOTCLIENT_ARG_OLDSTYLE"
+       default="-ORBInitRef NameService=corbaloc:iiop:localhost:2809/NameService" />
+
+  <!-- See https://github.com/start-jsk/rtmros_common/issues/416#issuecomment-46846623 -->
+  <node name="start_omninames" pkg="rtmbuild" type="start_omninames.sh"  args="$(arg corbaport)" />
+
+  <include file="$(find nextage_ros_bridge)/launch/nextage_ros_bridge_simulation.launch" >
+    <arg name="CORBAPORT" value="$(arg corbaport)" />
+    <arg name="GUI" value="$(arg GUI)" />
+  </include>
+  <!-- -->
+
+  <!-- follow the tutorials on  http://wiki.ros.org/rtmros_nextage/Tutorials/Programming_Hiro_NEXTAGE_OPEN_GUI
+       moveit_planning_execution.launch starts rviz so we run launch files except moviet_rviz.launch -->
+  <!-- <include file="$(find nextage_moveit_config)/launch/moveit_planning_execution.launch"> -->
+  <include file="$(find nextage_moveit_config)/launch/move_group.launch">
+    <arg name="publish_monitored_planning_scene" value="true" />
+  </include>
+  <include file="$(find nextage_moveit_config)/launch/planning_context.launch">
+    <arg name="load_robot_description" value="true"/>
+  </include>
+  <!-- -->
+
+  <!-- Check if MoveGroup is running -->
+  <arg name='TESTNAME_MG_STATUS' value='test_move_group' />
+  <test pkg="rostest" type="hztest" test-name="$(arg TESTNAME_MG_STATUS)" name="$(arg TESTNAME_MG_STATUS)" time-limit="60">
+    <param name="topic" value="/move_group/status" />
+    <param name="hz" value="5.0" />
+    <param name="hzerror" value="0.25" />
+    <param name="test_duration" value="10.0" />
+    <param name="wait_time" value="15.0" />
+  </test>  
+  
+  <test pkg="nextage_moveit_config" type="test_moveit.py" test-name="nxo_moveit"
+        time-limit="300"
+        args="" />
+         
+</launch>

--- a/nextage_moveit_config/test/test_moveit.py
+++ b/nextage_moveit_config/test/test_moveit.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2015, TORK (Tokyo Opensource Robotics Kyokai Association) 
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Tokyo Opensource Robotics Kyokai Association
+#    nor the names of its contributors may be used to endorse or promote 
+#    products derived from this software without specific prior written 
+#    permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Author: Isaac I.Y. Saito
+
+import unittest
+
+from geometry_msgs.msg import Pose
+from moveit_commander import MoveGroupCommander, MoveItCommanderException, RobotCommander
+from moveit_msgs.msg import RobotTrajectory
+import rospy
+
+import math
+from tf.transformations import quaternion_from_euler
+
+class TestDualarmMoveit(unittest.TestCase):
+    _KINEMATICSOLVER_SAFE = 'RRTConnectkConfigDefault'
+
+    _MOVEGROUP_NAME_TORSO = 'torso'
+    _JOINTNAMES_TORSO = ['CHEST_JOINT0']
+    # Set of MoveGroup name and the list of joints
+    _MOVEGROUP_ATTR_TORSO = [_MOVEGROUP_NAME_TORSO, _JOINTNAMES_TORSO]
+
+    _MOVEGROUP_NAME_LEFTARM = 'left_arm'
+    _JOINTNAMES_LEFTARM = ['LARM_JOINT0', 'LARM_JOINT1', 'LARM_JOINT2', 'LARM_JOINT3', 'LARM_JOINT4', 'LARM_JOINT5']
+    _MOVEGROUP_ATTR_LEFTARM = [_MOVEGROUP_NAME_LEFTARM, _JOINTNAMES_LEFTARM]
+
+    _MOVEGROUP_NAME_RIGHTARM = 'right_arm'
+    _JOINTNAMES_RIGHTARM = ['RARM_JOINT0', 'RARM_JOINT1', 'RARM_JOINT2', 'RARM_JOINT3', 'RARM_JOINT4', 'RARM_JOINT5']
+    _MOVEGROUP_ATTR_RIGHTARM = [_MOVEGROUP_NAME_RIGHTARM, _JOINTNAMES_RIGHTARM]
+
+    _MOVEGROUP_NAME_LEFTHAND = 'left_hand'
+    _JOINTNAMES_LEFTHAND = ['LARM_JOINT5']
+    _MOVEGROUP_ATTR_LEFTHAND = [_MOVEGROUP_NAME_LEFTHAND, _JOINTNAMES_LEFTHAND]
+
+    _MOVEGROUP_NAME_RIGHTHAND = 'right_hand'
+    _JOINTNAMES_RIGHTHAND = ['RARM_JOINT5']
+    _MOVEGROUP_ATTR_RIGHTHAND = [_MOVEGROUP_NAME_RIGHTHAND, _JOINTNAMES_RIGHTHAND]
+
+    _MOVEGROUP_NAME_HEAD = 'head'
+    _JOINTNAMES_HEAD = ['HEAD_JOINT0', 'HEAD_JOINT1']
+    _MOVEGROUP_ATTR_HEAD = [_MOVEGROUP_NAME_HEAD, _JOINTNAMES_HEAD]
+
+    _MOVEGROUP_NAME_BOTHARMS = 'botharms'
+    _JOINTNAMES_BOTHARMS = _JOINTNAMES_TORSO +_JOINTNAMES_LEFTARM + _JOINTNAMES_RIGHTARM
+    _MOVEGROUP_ATTR_BOTHARMS = [_MOVEGROUP_NAME_BOTHARMS, _JOINTNAMES_BOTHARMS]
+
+    _MOVEGROUP_NAME_UPPERBODY = 'upperbody'
+    _JOINTNAMES_UPPERBODY = _JOINTNAMES_TORSO + _JOINTNAMES_HEAD + _JOINTNAMES_LEFTARM + _JOINTNAMES_RIGHTARM
+    _MOVEGROUP_ATTR_UPPERBODY = [_MOVEGROUP_NAME_UPPERBODY, _JOINTNAMES_UPPERBODY]
+
+    # List of all MoveGroup set
+    _MOVEGROUP_NAMES = sorted([_MOVEGROUP_NAME_TORSO, _MOVEGROUP_NAME_HEAD,
+                               _MOVEGROUP_NAME_LEFTARM, _MOVEGROUP_NAME_RIGHTARM,
+                               _MOVEGROUP_NAME_LEFTHAND, _MOVEGROUP_NAME_RIGHTHAND,
+                               _MOVEGROUP_NAME_BOTHARMS, _MOVEGROUP_NAME_UPPERBODY])
+    _MOVEGROUP_ATTRS = [_MOVEGROUP_ATTR_TORSO, _MOVEGROUP_ATTR_HEAD,
+                        _MOVEGROUP_ATTR_LEFTARM, _MOVEGROUP_ATTR_RIGHTARM,
+                        _MOVEGROUP_ATTR_LEFTHAND, _MOVEGROUP_ATTR_RIGHTHAND,
+                        _MOVEGROUP_ATTR_BOTHARMS, _MOVEGROUP_ATTR_UPPERBODY]
+
+    _TARGETPOSE_LEFT = []  # TODO fill this
+
+#    def __init__(self, mg_attrs_larm, mg_attrs_rarm):
+#        '''
+#        @param mg_attrs_larm: List of MoveGroup attributes.
+#               See the member variable for the semantics of the data type.
+#        @type mg_attrs_larm: [str, [str]]
+#        '''
+
+    @classmethod
+    def setUpClass(self):
+
+        rospy.init_node('test_moveit')
+        rospy.sleep(5) # intentinally wait for starting up hrpsys
+
+        self.robot = RobotCommander()
+
+        # TODO: Read groups from SRDF file ideally.
+
+        for mg_attr in self._MOVEGROUP_ATTRS:
+            mg = MoveGroupCommander(mg_attr[0])
+            # Temporary workaround of planner's issue similar to https://github.com/tork-a/rtmros_nextage/issues/170
+            mg.set_planner_id(self._KINEMATICSOLVER_SAFE)
+            # Append MoveGroup instance to the MoveGroup attribute list.
+            mg_attr.append(mg)
+
+    @classmethod
+    def tearDownClass(self):
+        True  # TODO impl something meaningful
+
+    def _set_sample_pose(self):
+        '''
+        @return: Pose() with some values populated in.
+        '''
+        pose_target = Pose()
+        pose_target.orientation.x = 0.00
+        pose_target.orientation.y = 0.00
+        pose_target.orientation.z = -0.20
+        pose_target.orientation.w = 0.98
+        pose_target.position.x = 0.18
+        pose_target.position.y = -0.00
+        pose_target.position.z = 0.94
+        return pose_target
+
+    def _plan(self):
+        '''
+        Run `clear_pose_targets` at the beginning.
+        @rtype: RobotTrajectory http://docs.ros.org/api/moveit_msgs/html/msg/RobotTrajectory.html
+        '''
+        self._mvgroup.clear_pose_targets()
+
+        pose_target = self._set_sample_pose()
+        self._mvgroup.set_pose_target(pose_target)
+        plan = self._mvgroup.plan()
+        rospy.loginfo('  plan: '.format(plan))
+        return plan
+
+    def test_list_movegroups(self):
+        '''Check if the defined move groups are loaded.'''
+        self.assertEqual(self._MOVEGROUP_NAMES, sorted(self.robot.get_group_names()))
+
+    def test_list_activejoints(self):
+        '''Check if the defined joints in a move group are loaded.'''
+        for mg_attr in self._MOVEGROUP_ATTRS:
+            self.assertEqual(mg_attr[1],  # joint groups for a Move Group.
+                             sorted(mg_attr[2].get_active_joints()))
+
+    def _plan_leftarm(self, movegroup):
+        '''
+        @type movegroup: MoveGroupCommander
+        @rtype: RobotTrajectory http://docs.ros.org/api/moveit_msgs/html/msg/RobotTrajectory.html
+        '''
+        movegroup.clear_pose_targets()
+
+        pose_target = Pose()
+        pose_target.orientation.x = -0.32136357
+        pose_target.orientation.y = -0.63049522
+        pose_target.orientation.z = 0.3206799
+        pose_target.orientation.w = 0.62957575
+        pose_target.position.x = 0.32529
+        pose_target.position.y = 0.29919
+        pose_target.position.z = 0.24389
+
+        movegroup.set_pose_target(pose_target)
+        plan = movegroup.plan()  # TODO catch exception
+        rospy.loginfo('Plan: '.format(plan))
+        return plan
+
+    def test_plan_success(self):
+        '''Evaluate plan (RobotTrajectory)'''
+        plan = self._plan_leftarm(self._MOVEGROUP_ATTR_LEFTARM[2])
+        # TODO Better way to check the plan is valid.
+        # Currently the following checks if the number of waypoints is not zero,
+        # which (hopefully) indicates that a path is computed.
+        self.assertNotEqual(0, plan.joint_trajectory.points)
+
+    def test_planandexecute(self):
+        '''
+        Evaluate Plan and Execute works.
+        Currently no value checking is done (, which is better to be implemented)
+        '''
+        mvgroup = self._MOVEGROUP_ATTR_LEFTARM[2]
+        self._plan_leftarm(mvgroup)
+        # TODO Better way to check the plan is valid.
+        # The following checks if plan execution was successful or not.
+        self.assertTrue(mvgroup.go())
+
+    def test_left_and_right_plan(self):
+        '''
+        Check if http://wiki.ros.org/rtmros_nextage/Tutorials/Programming_Hiro_NEXTAGE_OPEN_MOVEIT works
+        '''
+        larm = self._MOVEGROUP_ATTR_LEFTARM[2]
+        rarm = self._MOVEGROUP_ATTR_RIGHTARM[2]
+
+        #Right Arm Initial Pose
+        rarm_initial_pose = rarm.get_current_pose().pose
+        print "=" * 10, " Printing Right Hand initial pose: "
+        print rarm_initial_pose
+
+        #Light Arm Initial Pose
+        larm_initial_pose = larm.get_current_pose().pose
+        print "=" * 10, " Printing Left Hand initial pose: "
+        print larm_initial_pose
+
+        target_pose_r = Pose()
+        target_pose_r.position.x = 0.325471850974-0.01
+        target_pose_r.position.y = -0.182271241593-0.3
+        target_pose_r.position.z = 0.0676272396419+0.3
+        target_pose_r.orientation.x = -0.000556712307053
+        target_pose_r.orientation.y = -0.706576742941
+        target_pose_r.orientation.z = -0.00102461782513
+        target_pose_r.orientation.w = 0.707635461636
+        rarm.set_pose_target(target_pose_r)
+
+        print "=" * 10," plan1 ..."
+        self.assertTrue(rarm.go())
+        rospy.sleep(1)
+
+        target_pose_l = [
+                target_pose_r.position.x,
+                -target_pose_r.position.y,
+                target_pose_r.position.z,
+                target_pose_r.orientation.x,
+                target_pose_r.orientation.y,
+                target_pose_r.orientation.z,
+                target_pose_r.orientation.w
+        ]
+        larm.set_pose_target(target_pose_l)
+
+        print "=" * 10," plan2 ..."
+        self.assertTrue(larm.go())
+        rospy.sleep(1)
+
+        #Clear pose
+        rarm.clear_pose_targets()
+
+        #Right Hand
+        target_pose_r.position.x = 0.221486843301
+        target_pose_r.position.y = -0.0746407547512
+        target_pose_r.position.z = 0.642545484602
+        target_pose_r.orientation.x = 0.0669013615474
+        target_pose_r.orientation.y = -0.993519060661
+        target_pose_r.orientation.z = 0.00834224628291
+        target_pose_r.orientation.w = 0.0915122442864
+        rarm.set_pose_target(target_pose_r)
+
+        print "=" * 10, " plan3..."
+        self.assertTrue(rarm.go())
+        rospy.sleep(1)
+
+        print "=" * 10,"Initial pose ..."
+        rarm.set_pose_target(rarm_initial_pose)
+        larm.set_pose_target(larm_initial_pose)
+        self.assertTrue(rarm.go())
+        self.assertTrue(larm.go())
+
+    def test_botharms_plan(self):
+        botharms = self._MOVEGROUP_ATTR_BOTHARMS[2]
+
+        target_pose_r = Pose()
+        target_pose_l = Pose()
+        q = quaternion_from_euler(0, -math.pi/2,0)
+        target_pose_r.position.x = 0.3
+        target_pose_r.position.y = 0.1
+        target_pose_r.position.z = 0.0
+        target_pose_r.orientation.x = q[0]
+        target_pose_r.orientation.y = q[1]
+        target_pose_r.orientation.z = q[2]
+        target_pose_r.orientation.w = q[3]
+        target_pose_l.position.x = 0.3
+        target_pose_l.position.y =-0.1
+        target_pose_l.position.z = 0.3
+        target_pose_l.orientation.x = q[0]
+        target_pose_l.orientation.y = q[1]
+        target_pose_l.orientation.z = q[2]
+        target_pose_l.orientation.w = q[3]
+        botharms.set_pose_target(target_pose_r, 'RARM_JOINT5_Link')
+        botharms.set_pose_target(target_pose_l, 'LARM_JOINT5_Link')
+        self.assertTrue(botharms.go())
+        rospy.sleep(1)
+
+        target_pose_r.position.x = 0.3
+        target_pose_r.position.y =-0.2
+        target_pose_r.position.z = 0.0
+        target_pose_l.position.x = 0.3
+        target_pose_l.position.y = 0.2
+        target_pose_l.position.z = 0.0
+        botharms.set_pose_target(target_pose_r, 'RARM_JOINT5_Link')
+        botharms.set_pose_target(target_pose_l, 'LARM_JOINT5_Link')
+        self.assertTrue(botharms.go())
+
+if __name__ == '__main__':
+    import rostest
+    rostest.rosrun('nextage_ros_bridge', 'test_moveit', TestDualarmMoveit) 

--- a/nextage_ros_bridge/launch/nextage_ros_bridge_simulation.launch
+++ b/nextage_ros_bridge/launch/nextage_ros_bridge_simulation.launch
@@ -5,10 +5,12 @@
   <arg name="GUI" default="true" />
   <arg name="MODEL_FILE" default="$(find nextage_description)/models/main.wrl" />
   <arg name="NAMESERVER" default="localhost" />
+  <arg name="LAUNCH_HRPSYSPY" default='true' />
 
   <include file="$(find nextage_ros_bridge)/launch/nextage_startup.launch" >
     <arg name="corbaport" value="$(arg CORBAPORT)" />
     <arg name="GUI" value="$(arg GUI)" />
+    <arg name="LAUNCH_HRPSYSPY" value='$(arg LAUNCH_HRPSYSPY)' />
   </include>
 
   <include file="$(find hironx_ros_bridge)/launch/hironx_ros_bridge.launch" >

--- a/nextage_ros_bridge/launch/nextage_startup.launch
+++ b/nextage_ros_bridge/launch/nextage_startup.launch
@@ -2,15 +2,16 @@
   <arg name="corbaport" default="2809" />
   <arg name="HRPSYS_PY_NAME" default="nextage.py"/>
   <arg name="HRPSYS_PY_PKG" default="nextage_ros_bridge"/>
+  <arg name="LAUNCH_HRPSYSPY" default='true' />
   <arg name="GUI" default="true" />
   <arg name="MODEL_FILE" default="$(find nextage_description)/models/main.wrl" />
-  <arg name="LAUNCH_HRPSYSPY" default='false' />  
   <arg name="REALTIME" default="false" />
   <include file="$(find hironx_ros_bridge)/launch/hironx_startup.launch">
     <arg name="CONF_FILE" value="$(find nextage_ros_bridge)/conf/nextage.conf" />
     <arg name="corbaport" value="$(arg corbaport)" />
     <arg name="HRPSYS_PY_NAME" value="$(arg HRPSYS_PY_NAME)"/>
     <arg name="HRPSYS_PY_PKG" value="$(arg HRPSYS_PY_PKG)"/>
+    <arg name="LAUNCH_HRPSYSPY" value='$(arg LAUNCH_HRPSYSPY)' />
     <arg name="GUI" value="$(arg GUI)" />
     <arg name="MODEL_FILE" value="$(arg MODEL_FILE)" />
     <arg name="PROJECT_FILE" value="$(find nextage_ros_bridge)/conf/nextage_nosim.xml" />

--- a/nextage_ros_bridge/test/nxo.test
+++ b/nextage_ros_bridge/test/nxo.test
@@ -1,10 +1,7 @@
 <launch>
   <arg name="corbaport" default="2809" />
-  <arg name="HRPSYS_PY_NAME" default="nextage.py"/>
-  <arg name="HRPSYS_PY_PKG" default="nextage_ros_bridge"/>
   <arg name="GUI" default='false' />
   <arg name="LAUNCH_HRPSYSPY" default="false" />
-  <arg name="REALTIME" default="false" />  
   <arg name="ROBOTCLIENT_ARG_OLDSTYLE"
        default="-ORBInitRef NameService=corbaloc:iiop:localhost:2809/NameService" />
 
@@ -12,13 +9,10 @@
   <node name="start_omninames" pkg="rtmbuild" type="start_omninames.sh"
         args="$(arg corbaport)" />
  
-  <include file="$(find hironx_ros_bridge)/launch/hironx_startup.launch" >
+  <include file="$(find nextage_ros_bridge)/launch/nextage_startup.launch" >
     <arg name="corbaport" value="$(arg corbaport)" />
-    <arg name="HRPSYS_PY_NAME" value="$(arg HRPSYS_PY_NAME)"/>
-    <arg name="HRPSYS_PY_PKG" value="$(arg HRPSYS_PY_PKG)"/>
     <arg name="GUI" value="$(arg GUI)" />
     <arg name="LAUNCH_HRPSYSPY" value='$(arg LAUNCH_HRPSYSPY)' />
-    <arg name="REALTIME" value="$(arg REALTIME)" />
   </include>
 
   <test type="test_handlight.py" pkg="nextage_ros_bridge" test-name="test_nxo_handlight"


### PR DESCRIPTION
running nextage_startup.launch with LAUNCH_HRPSYSPY cause problem when used with nxo.test, since nextage.py and test_*.py both call goInitial and go into dead lock situation, as reported on #604

note:
 LAUNCH_HIRONXPY is originally set to false, but it is not used
anywhare, and default vlaue for LAUNCH_HRPSYSPY in
hironx_startup.launch is true
https://github.com/start-jsk/rtmros_hironx/blob/1.1.3/hironx_ros_bridge/launch/hironx_startup.launch#L3
