### PR TITLE
[moveit config] (INCOMPLETE) Update botharms group to not depend on existing groups

### DIFF
--- a/nextage_moveit_config/config/NextageOpen.srdf
+++ b/nextage_moveit_config/config/NextageOpen.srdf
@@ -46,9 +46,18 @@
         <joint name="LARM_JOINT5" />
     </group>
     <group name="botharms">
-        <group name="right_arm" />
-        <group name="left_arm" />
-        <group name="torso" />
+        <joint name="LARM_JOINT0" />
+        <joint name="LARM_JOINT1" />
+        <joint name="LARM_JOINT2" />
+        <joint name="LARM_JOINT3" />
+        <joint name="LARM_JOINT4" />
+        <joint name="LARM_JOINT5" /> 
+        <joint name="RARM_JOINT0" />
+        <joint name="RARM_JOINT1" />
+        <joint name="RARM_JOINT2" />
+        <joint name="RARM_JOINT3" />
+        <joint name="RARM_JOINT4" />
+        <joint name="RARM_JOINT5" />       
     </group>
     <group name="head">
         <joint name="HEAD_JOINT0" />

--- a/nextage_moveit_config/config/controllers.yaml
+++ b/nextage_moveit_config/config/controllers.yaml
@@ -20,6 +20,22 @@ controller_list:
       - LARM_JOINT3
       - LARM_JOINT4
       - LARM_JOINT5
+  - name: botharms_controller
+    action_ns: follow_joint_trajectory_action
+    default: true
+    joints:
+      - LARM_JOINT0
+      - LARM_JOINT1
+      - LARM_JOINT2
+      - LARM_JOINT3
+      - LARM_JOINT4
+      - LARM_JOINT5      
+      - RARM_JOINT0
+      - RARM_JOINT1
+      - RARM_JOINT2
+      - RARM_JOINT3
+      - RARM_JOINT4
+      - RARM_JOINT5
   - name: head_controller
     action_ns: follow_joint_trajectory_action
     joints:

--- a/nextage_moveit_config/config/kinematics_ikfast.yaml
+++ b/nextage_moveit_config/config/kinematics_ikfast.yaml
@@ -8,6 +8,11 @@ left_arm:
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
   kinematics_solver_attempts: 3
+botharms:
+  kinematics_solver: nextage_right_arm_kinematics/IKFastKinematicsPlugin
+  kinematics_solver_search_resolution: 0.005
+  kinematics_solver_timeout: 0.005
+  kinematics_solver_attempts: 3
 head:
   kinematics_solver: nextage_right_arm_kinematics/IKFastKinematicsPlugin
   kinematics_solver_search_resolution: 0.005

--- a/nextage_moveit_config/config/kinematics_kdl.yaml
+++ b/nextage_moveit_config/config/kinematics_kdl.yaml
@@ -8,6 +8,11 @@ left_arm:
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
   kinematics_solver_attempts: 3
+botharms:
+  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+  kinematics_solver_search_resolution: 0.005
+  kinematics_solver_timeout: 0.005
+  kinematics_solver_attempts: 3
 head:
   kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005

--- a/nextage_moveit_config/config/ompl_planning.yaml
+++ b/nextage_moveit_config/config/ompl_planning.yaml
@@ -64,7 +64,7 @@ botharms:
     - TRRTkConfigDefault
     - PRMkConfigDefault
     - PRMstarkConfigDefault
-  projection_evaluator: joints(LARM_JOINT0,LARM_JOINT1)
+  projection_evaluator: joints(LARM_JOINT0,RARM_JOINT0)
   longest_valid_segment_fraction: 0.05
 head:
   planner_configs:


### PR DESCRIPTION
DO NOT MERGE.

Tackling #214 but not yet successful.
This PR (as of https://github.com/tork-a/rtmros_nextage/commit/269df8e63ef46c3863fed36241974d9baeabf5cf) I'm seeing more issues than in #214.

```
[ERROR] [1453172792.958765911, 14.125000000]: Group 'botharms' is not a chain
[ERROR] [1453172792.958850024, 14.125000000]: Kinematics solver of type 'kdl_kinematics_plugin/KDLKinematicsPlugin' could not be initialized for group 'botharms'
[ERROR] [1453172792.959396916, 14.125000000]: Kinematics solver could not be instantiated for joint group botharms.
[ INFO] [1453172792.964069619, 14.125000000]: Loading robot model 'NextageOpen'...
[ WARN] [1453172793.712751933, 14.885000000]: The root link WAIST has an inertia specified in the URDF, but KDL does not support a root link with an inertia.  As a workaround, you can add an extra dummy link to your URDF.
[ INFO] [1453172793.719860471, 14.895000000]: Loading robot model 'NextageOpen'...
[ERROR] [1453172794.495321440, 15.680000000]: Group 'torso' is not a chain
[ERROR] [1453172794.495367105, 15.680000000]: Kinematics solver of type 'kdl_kinematics_plugin/KDLKinematicsPlugin' could not be initialized for group 'torso'
[ERROR] [1453172794.495835454, 15.680000000]: Kinematics solver could not be instantiated for joint group torso.
[ INFO] [1453172794.612659298, 15.795000000]: Starting scene monitor
[ INFO] [1453172794.618140651, 15.800000000]: Listening to '/move_group/monitored_planning_scene'
[ WARN] [1453172796.929350231, 18.125000000]: The root link WAIST has an inertia specified in the URDF, but KDL does not support a root link with an inertia.  As a workaround, you can add an extra dummy link to your URDF.
[ WARN] [1453172796.929585902, 18.125000000]: The root link WAIST has an inertia specified in the URDF, but KDL does not support a root link with an inertia.  As a workaround, you can add an extra dummy link to your URDF.
[ WARN] [1453172796.929694631, 18.125000000]: The root link WAIST has an inertia specified in the URDF, but KDL does not support a root link with an inertia.  As a workaround, you can add an extra dummy link to your URDF.
[ INFO] [1453172796.933298665, 18.125000000]: Constructing new MoveGroup connection for group 'right_arm' in namespace ''
[ INFO] [1453172797.716892569, 18.915000000]: Ready to take MoveGroup commands for group right_arm.
[ INFO] [1453172797.717004306, 18.915000000]: Looking around: no
[ INFO] [1453172797.717091553, 18.915000000]: Replanning: no
[ INFO] [1453172804.582832061, 25.789999999]: Combined planning and execution request received for MoveGroup action. Forwarding to planning and execution pipeline.
[ WARN] [1453172804.583029293, 25.789999999]: Execution of motions should always start at the robot's current state. Ignoring the state supplied as start state in the motion planning request
[ INFO] [1453172804.583100793, 25.789999999]: Planning attempt 1 of at most 1
[ INFO] [1453172804.590345209, 25.799999999]: Planner configuration 'right_arm[RRTConnectkConfigDefault]' will use planner 'geometric::RRTConnect'. Additional configuration parameters will be set when the planner is constructed.
[ INFO] [1453172804.591775063, 25.799999999]: right_arm[RRTConnectkConfigDefault]: Starting planning with 1 states already in datastructure
[ INFO] [1453172804.591828313, 25.799999999]: right_arm[RRTConnectkConfigDefault]: Starting planning with 1 states already in datastructure
[ INFO] [1453172804.592223136, 25.799999999]: right_arm[RRTConnectkConfigDefault]: Starting planning with 1 states already in datastructure
[ INFO] [1453172804.592278213, 25.799999999]: right_arm[RRTConnectkConfigDefault]: Starting planning with 1 states already in datastructure
[ INFO] [1453172804.611604884, 25.804999999]: right_arm[RRTConnectkConfigDefault]: Created 5 states (2 start + 3 goal)
[ INFO] [1453172804.615021263, 25.809999999]: right_arm[RRTConnectkConfigDefault]: Created 6 states (2 start + 4 goal)
[ INFO] [1453172804.616201071, 25.814999999]: right_arm[RRTConnectkConfigDefault]: Created 5 states (3 start + 2 goal)
[ INFO] [1453172804.618074040, 25.814999999]: right_arm[RRTConnectkConfigDefault]: Created 6 states (2 start + 4 goal)
[ INFO] [1453172804.618289333, 25.814999999]: ParallelPlan::solve(): Solution found by one or more threads in 0.027370 seconds
[ INFO] [1453172804.618570253, 25.814999999]: right_arm[RRTConnectkConfigDefault]: Starting planning with 1 states already in datastructure
[ INFO] [1453172804.618621322, 25.814999999]: right_arm[RRTConnectkConfigDefault]: Starting planning with 1 states already in datastructure
[ INFO] [1453172804.618670523, 25.814999999]: right_arm[RRTConnectkConfigDefault]: Starting planning with 1 states already in datastructure
[ INFO] [1453172804.624265703, 25.824999999]: right_arm[RRTConnectkConfigDefault]: Starting planning with 1 states already in datastructure
[ INFO] [1453172804.629058341, 25.834999999]: right_arm[RRTConnectkConfigDefault]: Created 6 states (2 start + 4 goal)
[ INFO] [1453172804.630223424, 25.834999999]: right_arm[RRTConnectkConfigDefault]: Created 5 states (2 start + 3 goal)
[ INFO] [1453172804.635964187, 25.834999999]: right_arm[RRTConnectkConfigDefault]: Created 5 states (2 start + 3 goal)
[ INFO] [1453172804.637681395, 25.834999999]: right_arm[RRTConnectkConfigDefault]: Created 6 states (2 start + 4 goal)
[ INFO] [1453172804.637859682, 25.834999999]: ParallelPlan::solve(): Solution found by one or more threads in 0.019375 seconds
[ INFO] [1453172804.638162666, 25.834999999]: right_arm[RRTConnectkConfigDefault]: Starting planning with 1 states already in datastructure
[ INFO] [1453172804.638246603, 25.834999999]: right_arm[RRTConnectkConfigDefault]: Starting planning with 1 states already in datastructure
[ INFO] [1453172804.644527682, 25.844999999]: right_arm[RRTConnectkConfigDefault]: Created 5 states (2 start + 3 goal)
[ INFO] [1453172804.645025793, 25.849999999]: right_arm[RRTConnectkConfigDefault]: Created 5 states (2 start + 3 goal)
[ INFO] [1453172804.645206374, 25.849999999]: ParallelPlan::solve(): Solution found by one or more threads in 0.007157 seconds
[ INFO] [1453172804.650983591, 25.854999999]: SimpleSetup: Path simplification took 0.005578 seconds and changed from 4 to 2 states
[ INFO] [1453172817.708982086, 38.955000000]: Constructing new MoveGroup connection for group 'botharms' in namespace ''
[ INFO] [1453172818.059809329, 39.300000000]: Ready to take MoveGroup commands for group botharms.
[ INFO] [1453172818.060278083, 39.300000000]: Looking around: no
[ INFO] [1453172818.060316704, 39.300000000]: Replanning: no
[ INFO] [1453172820.716645793, 41.980000000]: Combined planning and execution request received for MoveGroup action. Forwarding to planning and execution pipeline.
[ WARN] [1453172820.716761090, 41.980000000]: Execution of motions should always start at the robot's current state. Ignoring the state supplied as start state in the motion planning request
[ INFO] [1453172820.716805091, 41.980000000]: Planning attempt 1 of at most 1
[ INFO] [1453172820.721041688, 41.980000000]: No planner specified. Using default.
[ INFO] [1453172820.721245643, 41.980000000]: LBKPIECE1: Attempting to use default projection.
[ INFO] [1453172820.721544393, 41.980000000]: LBKPIECE1: Attempting to use default projection.
[ INFO] [1453172820.721706723, 41.980000000]: LBKPIECE1: Attempting to use default projection.
[ INFO] [1453172820.721844141, 41.980000000]: LBKPIECE1: Attempting to use default projection.
[ INFO] [1453172820.723478555, 41.980000000]: LBKPIECE1: Attempting to use default projection.
[ INFO] [1453172820.723560523, 41.980000000]: LBKPIECE1: Starting planning with 1 states already in datastructure
[ INFO] [1453172820.723626130, 41.980000000]: LBKPIECE1: Starting planning with 1 states already in datastructure
[ INFO] [1453172820.723725243, 41.980000000]: LBKPIECE1: Starting planning with 1 states already in datastructure
[ INFO] [1453172820.723827125, 41.980000000]: LBKPIECE1: Starting planning with 1 states already in datastructure
[ INFO] [1453172821.072707757, 42.340000000]: LBKPIECE1: Created 104 (34 start + 70 goal) states in 88 cells (32 start (32 on boundary) + 56 goal (56 on boundary))
[ INFO] [1453172821.230419607, 42.475000000]: LBKPIECE1: Created 124 (61 start + 63 goal) states in 108 cells (56 start (56 on boundary) + 52 goal (52 on boundary))
[ INFO] [1453172821.553701575, 42.805000000]: LBKPIECE1: Created 191 (67 start + 124 goal) states in 174 cells (64 start (63 on boundary) + 110 goal (110 on boundary))
[ INFO] [1453172821.593422134, 42.845000000]: LBKPIECE1: Created 155 (73 start + 82 goal) states in 133 cells (70 start (70 on boundary) + 63 goal (63 on boundary))
[ INFO] [1453172822.222216423, 43.475000000]: ParallelPlan::solve(): Solution found by one or more threads in 1.500669 seconds
[ INFO] [1453172822.222788324, 43.475000000]: LBKPIECE1: Attempting to use default projection.
[ INFO] [1453172822.222868489, 43.475000000]: LBKPIECE1: Attempting to use default projection.
[ INFO] [1453172822.222946493, 43.475000000]: LBKPIECE1: Attempting to use default projection.
[ INFO] [1453172822.222994011, 43.475000000]: LBKPIECE1: Starting planning with 1 states already in datastructure
[ INFO] [1453172822.223045223, 43.475000000]: LBKPIECE1: Attempting to use default projection.
[ INFO] [1453172822.223131976, 43.475000000]: LBKPIECE1: Starting planning with 1 states already in datastructure
[ INFO] [1453172822.223220275, 43.475000000]: LBKPIECE1: Starting planning with 1 states already in datastructure
[ INFO] [1453172822.223267690, 43.475000000]: LBKPIECE1: Starting planning with 1 states already in datastructure
[ INFO] [1453172822.332851334, 43.600000000]: LBKPIECE1: Created 71 (6 start + 65 goal) states in 57 cells (5 start (5 on boundary) + 52 goal (52 on boundary))
[ INFO] [1453172822.454387983, 43.705000000]: LBKPIECE1: Created 169 (12 start + 157 goal) states in 147 cells (11 start (11 on boundary) + 136 goal (136 on boundary))
[ INFO] [1453172822.604681731, 43.855000000]: LBKPIECE1: Created 92 (47 start + 45 goal) states in 77 cells (45 start (45 on boundary) + 32 goal (32 on boundary))
[ INFO] [1453172822.736038579, 43.985000000]: LBKPIECE1: Created 147 (43 start + 104 goal) states in 124 cells (39 start (39 on boundary) + 85 goal (85 on boundary))
[ INFO] [1453172824.837969231, 46.095000000]: ParallelPlan::solve(): Solution found by one or more threads in 2.615199 seconds
[ INFO] [1453172824.838522690, 46.095000000]: LBKPIECE1: Attempting to use default projection.
[ INFO] [1453172824.838621189, 46.095000000]: LBKPIECE1: Attempting to use default projection.
[ INFO] [1453172824.838714428, 46.095000000]: LBKPIECE1: Starting planning with 1 states already in datastructure
[ INFO] [1453172824.838758328, 46.095000000]: LBKPIECE1: Starting planning with 1 states already in datastructure
[ INFO] [1453172825.387101231, 46.655000000]: LBKPIECE1: Created 126 (83 start + 43 goal) states in 112 cells (80 start (80 on boundary) + 32 goal (32 on boundary))
[ INFO] [1453172825.726574403, 46.985000000]: LBKPIECE1: Created 154 (56 start + 98 goal) states in 135 cells (51 start (51 on boundary) + 84 goal (84 on boundary))
[ INFO] [1453172826.344437025, 47.625000000]: ParallelPlan::solve(): Solution found by one or more threads in 1.505929 seconds
[ INFO] [1453172831.392601509, 52.695000000]: Waiting for botharms_controller/follow_joint_trajectory_action to come up
[ INFO] [1453172836.388350667, 57.700000000]: Waiting for botharms_controller/follow_joint_trajectory_action to come up
[ERROR] [1453172841.374295781, 62.700000000]: Action client not connected: botharms_controller/follow_joint_trajectory_action
[ERROR] [1453172841.421094846, 62.740000000]: No controller handle for controller 'botharms_controller'. Aborting.
[ INFO] [1453172841.602899886, 62.895000000]: ABORTED: Solution found but controller failed during execution
```

I now began to think that the controller in use (that is from PR2) may not be capable of joints from dual-arm?
