### PR TITLE
[moveit] Use RRT as default (workaround/fix #170)

### DIFF
--- a/nextage_moveit_config/config/ompl_planning.yaml
+++ b/nextage_moveit_config/config/ompl_planning.yaml
@@ -22,6 +22,7 @@ planner_configs:
   PRMstarkConfigDefault:
     type: geometric::PRMstar
 right_arm:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault
@@ -37,6 +38,7 @@ right_arm:
   projection_evaluator: joints(RARM_JOINT0,RARM_JOINT1)
   longest_valid_segment_fraction: 0.05
 left_arm:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault
@@ -52,6 +54,7 @@ left_arm:
   projection_evaluator: joints(LARM_JOINT0,LARM_JOINT1)
   longest_valid_segment_fraction: 0.05
 botharms:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault
@@ -67,6 +70,7 @@ botharms:
   projection_evaluator: joints(LARM_JOINT0,LARM_JOINT1)
   longest_valid_segment_fraction: 0.05
 head:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault
@@ -82,6 +86,7 @@ head:
   projection_evaluator: joints(HEAD_JOINT0,HEAD_JOINT1)
   longest_valid_segment_fraction: 0.05
 torso:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault
@@ -97,6 +102,7 @@ torso:
   projection_evaluator: joints(CHEST_JOINT0)
   longest_valid_segment_fraction: 0.05
 upperbody:
+  default_planner_config: RRTConnectkConfigDefault
   planner_configs:
     - SBLkConfigDefault
     - ESTkConfigDefault


### PR DESCRIPTION
Following the recent change in other moveit_config package (e.g. https://github.com/ros-planning/moveit_robots/pull/41#issue-131963734). 
This should work around the persistently annoying #170.
