### PR TITLE
Fix missing interactive markers

### DIFF
--- a/nextage_description/urdf/NextageOpen.urdf
+++ b/nextage_description/urdf/NextageOpen.urdf
@@ -34,13 +34,6 @@
     </transmission>
   </xacro:macro>
 
-  <!-- Used for fixing robot to Gazebo 'base_link' -->
-  <link name="world"/>
-  <joint name="fixed" type="fixed">
-    <parent link="world"/>
-    <child link="WAIST"/>
-  </joint>
-
   <xacro:gazebo_nx_link name="WAIST" color="Black" />
   <link name="WAIST">
     <visual>

--- a/nextage_moveit_config/launch/moveit.rviz
+++ b/nextage_moveit_config/launch/moveit.rviz
@@ -342,7 +342,7 @@ Visualization Manager:
         Colliding Link Color: 255; 0; 0
         Goal State Alpha: 1
         Goal State Color: 250; 128; 0
-        Interactive Marker Size: 0
+        Interactive Marker Size: 0.25
         Joint Violation Color: 255; 0; 255
         Planning Group: left_arm
         Query Goal State: true

--- a/nextage_moveit_config/test/nxo_moveit.test
+++ b/nextage_moveit_config/test/nxo_moveit.test
@@ -46,6 +46,6 @@
     <param name="hz" value="2.0" />
     <param name="hzerror" value="0.25" />
     <param name="test_duration" value="10.0" />
-    <param name="wait_time" value="15.0" />
+    <param name="wait_time" value="120.0" />
   </test>  
 </launch>

--- a/nextage_moveit_config/test/nxo_moveit.test
+++ b/nextage_moveit_config/test/nxo_moveit.test
@@ -37,5 +37,15 @@
   <test pkg="nextage_moveit_config" type="test_moveit.py" test-name="nxo_moveit"
         time-limit="300"
         args="" />
-         
+
+  <!-- Check if InteractiveMarker is running -->
+  <arg name='TESTNAME_IMARKER_STATUS' value='test_interactivemarker_running' />
+  <test pkg="rostest" type="hztest" test-name="$(arg TESTNAME_IMARKER_STATUS)"
+        name="$(arg TESTNAME_IMARKER_STATUS)" time-limit="60">
+    <param name="topic" value="/rviz_moveit_motion_planning_display/robot_interaction_interactive_marker_topic/update" />
+    <param name="hz" value="2.0" />
+    <param name="hzerror" value="0.25" />
+    <param name="test_duration" value="10.0" />
+    <param name="wait_time" value="15.0" />
+  </test>  
 </launch>


### PR DESCRIPTION
Looks like `interactive markers` haven't been available, since #223. I followed [Gazebo tutorial](http://gazebosim.org/tutorials?tut=ros_urdf#RigidlyFixingAModeltotheWorld) to add a new fixed link in URDF, which seems to have introduced a bug.

I think fixed link isn't needed for NEXTAGE Open anyway, as there can be possibly mobile applications.
