### PR TITLE
Specify collada file location for real.launch.

### DIFF
--- a/nextage_ros_bridge/conf/realrobot_fixedpath.conf
+++ b/nextage_ros_bridge/conf/realrobot_fixedpath.conf
@@ -1,0 +1,4 @@
+collision_pair: RARM_JOINT2:LARM_JOINT2 RARM_JOINT3:LARM_JOINT3 RARM_JOINT4:LARM_JOINT4 RARM_JOINT5:LARM_JOINT5
+
+model: file:///opt/jsk/etc/NEXTAGE/model/main.wrl
+dt: 0.005

--- a/nextage_ros_bridge/launch/nextage_ros_bridge_real.launch
+++ b/nextage_ros_bridge/launch/nextage_ros_bridge_real.launch
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="CONF_FILE_COLLISIONDETECT" default="$(find hironx_ros_bridge)/conf/hironx_realrobot_fixedpath.conf" />
+  <arg name="CONF_FILE_COLLISIONDETECT" default="$(find nextage_ros_bridge)/conf/realrobot_fixedpath.conf" />
   <arg name="corbaport" default="15005" />
   <arg name="MODEL_FILE" default="/opt/jsk/etc/NEXTAGE/model/main.wrl" /> <!-- This shouldn't be changed unless you know what you're doing; this is the location of vrml file internal to the robot (on QNX OS). -->
   <arg name="nameserver" default="nextage" /> <!-- Host name of the QNX. -->

--- a/nextage_ros_bridge/launch/nextage_ros_bridge_real.launch
+++ b/nextage_ros_bridge/launch/nextage_ros_bridge_real.launch
@@ -1,4 +1,5 @@
 <launch>
+  <arg name="COLLADA_FILE" default="$(find nextage_description)/models/main.dae" /> 
   <arg name="CONF_FILE_COLLISIONDETECT" default="$(find nextage_ros_bridge)/conf/realrobot_fixedpath.conf" />
   <arg name="corbaport" default="15005" />
   <arg name="MODEL_FILE" default="/opt/jsk/etc/NEXTAGE/model/main.wrl" /> <!-- This shouldn't be changed unless you know what you're doing; this is the location of vrml file internal to the robot (on QNX OS). -->
@@ -8,6 +9,7 @@
   <env name="RTCTREE_NAMESERVERS" value="$(arg nameserver):$(arg corbaport)" />
 
   <include file="$(find hironx_ros_bridge)/launch/hironx_ros_bridge_real.launch" >
+    <arg name="COLLADA_FILE" value="$(arg COLLADA_FILE)" /> 
     <arg name="CONF_FILE_COLLISIONDETECT" value="$(arg CONF_FILE_COLLISIONDETECT)" />
     <arg name="corbaport" value="$(arg corbaport)" />
     <arg name="MODEL_FILE" value="$(arg MODEL_FILE)" />

--- a/nextage_ros_bridge/package.xml
+++ b/nextage_ros_bridge/package.xml
@@ -17,11 +17,11 @@
   <url type="repository">https://github.com/tork-a/rtmros_nextage</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend version_gte="1.0.17">hironx_ros_bridge</build_depend>
+  <build_depend version_gte="1.1.13">hironx_ros_bridge</build_depend>
   <build_depend>nextage_description</build_depend>
   <build_depend>roslint</build_depend>
   
-  <run_depend version_gte="1.0.17">hironx_ros_bridge</run_depend>
+  <run_depend version_gte="1.1.13">hironx_ros_bridge</run_depend>
   <run_depend>nextage_description</run_depend>
   <run_depend>ueye_cam</run_depend>
 


### PR DESCRIPTION
A partial solution to the issue https://github.com/tork-a/rtmros_nextage/issues/244, which a NEXTAGE Open real robot owner is reporting and seems to be happening because the model files from two similar but not identical robots are being used.

With this PR, together with https://github.com/start-jsk/rtmros_hironx/pull/463, we will be able to specify the collada file location from NEXTAGE Open package so that wrong model files won't be used.

https://github.com/start-jsk/rtmros_hironx/pull/463 needs merged first.
