### PR TITLE
kinematics_ikfast.yaml : no ik fast plugin for head and torso

### DIFF
--- a/nextage_moveit_config/config/kinematics_ikfast.yaml
+++ b/nextage_moveit_config/config/kinematics_ikfast.yaml
@@ -9,12 +9,13 @@ left_arm:
   kinematics_solver_timeout: 0.005
   kinematics_solver_attempts: 3
 head:
-  kinematics_solver: nextage_right_arm_kinematics/IKFastKinematicsPlugin
+  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
   kinematics_solver_attempts: 3
 torso:
-  kinematics_solver: nextage_left_arm_kinematics/IKFastKinematicsPlugin
+  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005
   kinematics_solver_attempts: 3
+

--- a/nextage_moveit_config/launch/move_group.launch
+++ b/nextage_moveit_config/launch/move_group.launch
@@ -15,8 +15,10 @@
   <arg name="jiggle_fraction" default="0.05" />
   <arg name="publish_monitored_planning_scene" default="true"/>
 
+  <arg name="kinematics_conf_file" default="$(find nextage_moveit_config)/config/kinematics_kdl.yaml"/>
   <include ns="move_group" file="$(find nextage_moveit_config)/launch/planning_pipeline.launch">
     <arg name="pipeline" value="ompl" />
+    <arg name="kinematics_conf_file" value="$(arg kinematics_conf_file)"/>
   </include>
 
   <include ns="move_group" file="$(find nextage_moveit_config)/launch/trajectory_execution.launch" if="$(arg allow_trajectory_execution)">

--- a/nextage_moveit_config/launch/moveit_planning_execution.launch
+++ b/nextage_moveit_config/launch/moveit_planning_execution.launch
@@ -6,6 +6,7 @@
  # and the current state of the world as seen by the planner.
  <include file="$(find nextage_moveit_config)/launch/move_group.launch">
   <arg name="publish_monitored_planning_scene" value="true" />
+  <arg name="kinematics_conf_file" value="$(arg kinematics_conf)"/>
  </include>
  # The visualization component of MoveIt!
  <include file="$(find nextage_moveit_config)/launch/moveit_rviz.launch"> 

--- a/nextage_moveit_config/launch/planning_pipeline.launch
+++ b/nextage_moveit_config/launch/planning_pipeline.launch
@@ -4,7 +4,9 @@
        It is assumed that all planning pipelines are named XXX_planning_pipeline.launch  -->  
 
   <arg name="pipeline" default="ompl" />
+  <arg name="kinematics_conf_file" default="$(find nextage_moveit_config)/config/kinematics_kdl.yaml"/>
 
-  <include file="$(find nextage_moveit_config)/launch/$(arg pipeline)_planning_pipeline.launch" />
-
+  <include file="$(find nextage_moveit_config)/launch/$(arg pipeline)_planning_pipeline.launch">
+    <arg name="kinematics_conf_file" value="$(arg kinematics_conf_file)"/>
+  </include>
 </launch>


### PR DESCRIPTION
current setup outputs following error, which make sence because we do not created ikfast plugin for head and torso, so use kdl

```
[ INFO] [1472919450.530481088, 53.710000000]: LARM_JOINT4 -1.74533 1.74533 1
[ INFO] [1472919450.530503958, 53.710000000]: LARM_JOINT5 -2.84489 2.84489 1
[FATAL] [1472919450.542292382, 53.730000000]: Joint numbers mismatch: URDF has 2 and IKFast has 6
[ERROR] [1472919450.542426915, 53.730000000]: Kinematics solver of type 'nextage_right_arm_kinematics/IKFastKinematicsPlugin' could not be initialized for group 'head'
[ERROR] [1472919450.542665573, 53.730000000]: Kinematics solver could not be instantiated for joint group head.
[FATAL] [1472919450.551285289, 53.735000000]: Joint numbers mismatch: URDF has 1 and IKFast has 6
[ERROR] [1472919450.551665721, 53.740000000]: Kinematics solver of type 'nextage_left_arm_kinematics/IKFastKinematicsPlugin' could not be initialized for group 'torso'
[ERROR] [1472919450.551711005, 53.740000000]: Kinematics solver could not be instantiated for joint group torso.
[ INFO] [1472919450.661796446, 53.845000000]: Starting scene monitor
```

c.f. #187
