### PR TITLE
Add convenient launch file for NXO with hrpsys older than 315.2.7.

### DIFF
--- a/nextage_ros_bridge/launch/nextage_ros_bridge_real_hrpsys315.2.7-.launch
+++ b/nextage_ros_bridge/launch/nextage_ros_bridge_real_hrpsys315.2.7-.launch
@@ -1,0 +1,12 @@
+<launch>
+  <arg name="COLLADA_FILE" default="$(find nextage_description)/models/main.dae" /> 
+  <arg name="CONF_FILE_COLLISIONDETECT" default="$(find nextage_ros_bridge)/conf/realrobot_fixedpath.conf" />
+  <arg name="corbaport" default="15005" />
+  <arg name="MODEL_FILE" default="/opt/jsk/etc/HIRONX/model/main.wrl" /> <!-- This MUST NOT be changed. -->
+  <arg name="nameserver" default="nextage" /> <!-- Host name of the QNX. -->
+  <arg name="USE_SERVOCONTROLLER" default="false" />
+
+  <env name="RTCTREE_NAMESERVERS" value="$(arg nameserver):$(arg corbaport)" />
+
+  <include file="$(find nextage_ros_bridge)/launch/nextage_ros_bridge_real.launch" pass_all_args="true" />
+</launch>


### PR DESCRIPTION
From https://github.com/tork-a/rtmros_nextage/issues/153, on the robots with `hrpsys` older than 315.2.8 you have to manually add an argument `MODEL_FILE:=/opt/jsk/etc/HIRONX/model/main.wrl`, which is not only cumbersome but error-prone. With this PR, they can simply run the following **without** the argument:

```
roslaunch nextage_ros_bridge nextage_ros_bridge_real_hrpsys315.2.7-.launch
```
