### PR TITLE
[nextage.py script] users with older dio spec robot can specify dio version upon starting the script

### DIFF
--- a/nextage_ros_bridge/script/nextage.py
+++ b/nextage_ros_bridge/script/nextage.py
@@ -50,6 +50,9 @@ if __name__ == '__main__':
     parser.add_argument('--port', help='corba name server port number')
     parser.add_argument('--modelfile', help='robot model file nmae')
     parser.add_argument('--robot', help='robot modlule name (RobotHardware0 for real robot, Robot()')
+    parser.add_argument('--dio_ver', help="Version of digital I/O. Only users "
+                        "whose robot was shipped before Aug 2014 need to "
+                        "define this, and the value should be '0.4.2'.")
     args, unknown = parser.parse_known_args()
 
     if args.host:
@@ -72,6 +75,9 @@ if __name__ == '__main__':
     # This is backward compatible so that users can still keep using `nxc`.
     # See http://code.google.com/p/rtm-ros-robotics/source/detail?r=6926
     robot.init(robotname=args.robot, url=args.modelfile)
+
+    if args.dio_ver:
+        robot.set_hand_version(args.dio_ver)
 
     # ROS Client.
     ros = ROS_Client()


### PR DESCRIPTION
Enhancement for https://github.com/tork-a/rtmros_nextage/issues/274#issuecomment-271604451

You can start the `nextage.py` script with specifying dio version as the following, and see the version is already set as specified.

```
$ ipython -i `rospack find nextage_ros_bridge`/script/nextage.py -- --dio_ver 0.4.2
:
In [1]: robot.get_hand_version()
Out[1]: '0.4.2'
```

Note that only users who own the robot with older spec needs this; newer robot owners don't need to change anything.