### PR TITLE
[moveit conf] Add kinematics config for trac_ik.

### DIFF
--- a/nextage_moveit_config/config/kinematics_tracik.yaml
+++ b/nextage_moveit_config/config/kinematics_tracik.yaml
@@ -1,0 +1,25 @@
+right_arm:
+  kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+  kinematics_solver_search_resolution: 0.005
+  kinematics_solver_timeout: 0.005
+  kinematics_solver_attempts: 3
+left_arm:
+  kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+  kinematics_solver_search_resolution: 0.005
+  kinematics_solver_timeout: 0.005
+  kinematics_solver_attempts: 3
+# botharms:
+#   kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+#   kinematics_solver_search_resolution: 0.005
+#   kinematics_solver_timeout: 0.005
+#   kinematics_solver_attempts: 3
+right_arm_torso:
+  kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+  kinematics_solver_search_resolution: 0.005
+  kinematics_solver_timeout: 0.005
+  kinematics_solver_attempts: 3
+left_arm_torso:
+  kinematics_solver: trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
+  kinematics_solver_search_resolution: 0.005
+  kinematics_solver_timeout: 0.005
+  kinematics_solver_attempts: 3

--- a/nextage_moveit_config/package.xml
+++ b/nextage_moveit_config/package.xml
@@ -26,6 +26,7 @@
   <run_depend>moveit_ros_visualization</run_depend>
   <run_depend>nextage_ros_bridge</run_depend>
   <run_depend>pr2_moveit_plugins</run_depend>
+  <run_depend>trac_ik_kinematics_plugin</run_depend>
 
   <test_depend>rostest</test_depend>
   <test_depend>joint_state_publisher</test_depend>

--- a/nextage_moveit_config/test/moveit_trackik.test
+++ b/nextage_moveit_config/test/moveit_trackik.test
@@ -1,0 +1,5 @@
+<launch>
+  <arg name="kinematics_conf" default="$(find nextage_moveit_config)/config/kinematics_tracik.yaml" />
+
+  <include file="$(find nextage_ros_bridge)/test/nxo_moveit.test" pass_all_args="true" />
+</launch>

--- a/nextage_moveit_config/test/nxo_moveit.test
+++ b/nextage_moveit_config/test/nxo_moveit.test
@@ -38,7 +38,6 @@
   </test>  
   
   <test pkg="nextage_moveit_config" type="test_moveit.py" test-name="nxo_moveit"
-        time-limit="300"
-        args="" />
+        time-limit="600" args="" />
          
 </launch>

--- a/nextage_moveit_config/test/nxo_moveit.test
+++ b/nextage_moveit_config/test/nxo_moveit.test
@@ -1,6 +1,8 @@
 <launch>
   <arg name="corbaport" default="2809" />
+  <arg name="kinematics_conf_file" default="$(find nextage_moveit_config)/config/kinematics_kdl.yaml" />
   <arg name="GUI" default='false' />
+  <arg name="publish_monitored_planning_scene" default="true" />
   <arg name="ROBOTCLIENT_ARG_OLDSTYLE"
        default="-ORBInitRef NameService=corbaloc:iiop:localhost:2809/NameService" />
 
@@ -17,7 +19,8 @@
        moveit_planning_execution.launch starts rviz so we run launch files except moviet_rviz.launch -->
   <!-- <include file="$(find nextage_moveit_config)/launch/moveit_planning_execution.launch"> -->
   <include file="$(find nextage_moveit_config)/launch/move_group.launch">
-    <arg name="publish_monitored_planning_scene" value="true" />
+    <arg name="kinematics_conf_file" value="$(arg kinematics_conf_file)" />
+    <arg name="publish_monitored_planning_scene" value="$(arg publish_monitored_planning_scene)" />
   </include>
   <include file="$(find nextage_moveit_config)/launch/planning_context.launch">
     <arg name="load_robot_description" value="true"/>


### PR DESCRIPTION
Simple addition for utilizing [trac_ik](http://wiki.ros.org/trac_ik) package. You can run by:

```
roslaunch nextage_moveit_config moveit_planning_execution.launch kinematics_conf:=`rospack find nextage_moveit_config`/config/kinematics_tracik.yaml
```
