### PR TITLE
Revert #239 (temporary, hotfix to #308)

### DIFF
--- a/nextage_ros_bridge/src/nextage_ros_bridge/nextage_client.py
+++ b/nextage_ros_bridge/src/nextage_ros_bridge/nextage_client.py
@@ -330,18 +330,20 @@ class NextageClient(HIRONX, object):
         '''
         Overwriting HrpsysConfigurator.getRTCList
         Returning predefined list of RT components.
-
-        As of March 2016, this method internally calls HIRONX.getRTCList() and
-        returns what it returns. Although we could simply remove this method
-        from NextageClient, we still keep it; it'd be easier
-        to modify an existing method than to add a new overridden method,
-        in case we might want to define RTC return list differently from HIRONX.
-
         @rtype [[str]]
         @return List of available components. Each element consists of a list
                  of abbreviated and full names of the component.
         '''
-        return HIRONX.getRTCList(self)
+        return [
+            ['seq', "SequencePlayer"],
+            ['sh', "StateHolder"],
+            ['fk', "ForwardKinematics"],
+            ['el', "SoftErrorLimiter"],
+            # ['co', "CollisionDetector"],
+            # ['sc', "ServoController"],
+            ['ic', "ImpedanceController"],
+            ['log', "DataLogger"]
+            ]
 
     def goInitial(self, tm=7, wait=True, init_pose_type=0):
         '''


### PR DESCRIPTION
Reverts tork-a/rtmros_nextage#239 as a tot temporary fix to #308, which is critical.

Better, permanent fix is WIP https://github.com/start-jsk/rtmros_hironx/pull/497 and https://github.com/tork-a/rtmros_nextage/pull/316.