### PR TITLE
[ros_bridge] Fix a launch file name to appropriately indicate "older than" 315.2.7.

### DIFF
--- a/nextage_ros_bridge/launch/nextage_ros_bridge_real_-hrpsys315.2.7.launch
+++ b/nextage_ros_bridge/launch/nextage_ros_bridge_real_-hrpsys315.2.7.launch
@@ -1,4 +1,6 @@
 <launch>
+  <!-- This file is targeted for the robot that runs on hrpsys older than the version 315.2.7.
+       For those on newer version use nextage_ros_bridge_real.launch. -->
   <arg name="COLLADA_FILE" default="$(find nextage_description)/models/main.dae" /> 
   <arg name="CONF_FILE_COLLISIONDETECT" default="$(find nextage_ros_bridge)/conf/realrobot_fixedpath.conf" />
   <arg name="corbaport" default="15005" />


### PR DESCRIPTION
Hyphen here is used to indicate the file is intended for the mentioned version or larger/smaller.

"*version-.launch" sounds like the launch is targeted for the version or larger while in fact we wanted to mean the opposite.

@hectorherrero Do you think you're using the launch file renamed in this PR? You're the one of only a few users who could be affected by this.