### PR TITLE
[ros_bridge] Missing dependency for using stereo vision.

### DIFF
--- a/nextage_ros_bridge/package.xml
+++ b/nextage_ros_bridge/package.xml
@@ -23,6 +23,7 @@
   
   <run_depend version_gte="1.1.13">hironx_ros_bridge</run_depend>
   <run_depend>nextage_description</run_depend>
+  <run_depend>stereo_image_proc</run_depend>
   <run_depend>ueye_cam</run_depend>
 
   <test_depend>rostest</test_depend>


### PR DESCRIPTION
This dependency won't be necessary unless stereo vision is in use, but the advantage of having necessary pkg installed without the need for worrying surpasses disadvantage.