### PR TITLE
[Collision detector] Add a conf file for the robot that was installed before 2015.

### DIFF
--- a/nextage_ros_bridge/conf/realrobot_fixedpath_-2015.conf
+++ b/nextage_ros_bridge/conf/realrobot_fixedpath_-2015.conf
@@ -1,0 +1,4 @@
+collision_pair: RARM_JOINT2:LARM_JOINT2 RARM_JOINT3:LARM_JOINT3 RARM_JOINT4:LARM_JOINT4 RARM_JOINT5:LARM_JOINT5
+
+model: file:///opt/jsk/etc/HIRONX/model/main.wrl
+dt: 0.005


### PR DESCRIPTION
**Issue**
An error about `CollisionDetector` such as below or similar might be happening constantly, even though the path in `MODEL_FILE` is correct.
```
$ roslaunch nextage_ros_bridge nextage_ros_bridge_real.launch MODEL_FILE:=/opt/jsk/etc/HIRONX/model/main.wrl

or

$ roslaunch nextage_ros_bridge nextage_ros_bridge_real.launch MODEL_FILE:=/opt/jsk/etc/HIRONX/model/main.wrl nameserver:=nextage
:
[WARN] [WallTime: 1495434563.800814] Could not found CollisionDetector(CollisionDetector0), waiting...
```

**Cause**
In [nextage_ros_bridge/conf/realrobot_fixedpath.con](https://github.com/tork-a/rtmros_nextage/blob/a1c21751189a6ea5244519d34f560f288a3d94f9/nextage_ros_bridge/conf/realrobot_fixedpath.conf#L3) (that is passed from [nextage_ros_bridge_real.launch](https://github.com/tork-a/rtmros_nextage/blob/a1c21751189a6ea5244519d34f560f288a3d94f9/nextage_ros_bridge/launch/nextage_ros_bridge_real.launch#L3)) the model file location is hardcoded as:
```
model: file:///opt/jsk/etc/NEXTAGE/model/main.wrl
```

But this path does not exist for robots that were installed earlier (unless robot owners changed by themselves).

**Workaround**
With this commit, you'll be able to specify a correct conf file like this:

```
roslaunch nextage_ros_bridge nextage_ros_bridge_real.launch MODEL_FILE:=/opt/jsk/etc/HIRONX/model/main.wrl nameserver:=nextage CONF_FILE_COLLISIONDETECT:=`rospack find nextage_ros_bridge`/conf/realrobot_fixedpath_-2015.conf
```