### PR TITLE
[nextage_gazebo/package.xml] add gazebo_model_path setting

### DIFF
--- a/nextage_gazebo/package.xml
+++ b/nextage_gazebo/package.xml
@@ -19,5 +19,6 @@
   <run_depend>ros_controllers</run_depend>
   <test_depend>rostest</test_depend>
   <export>
+    <gazebo_ros gazebo_model_path="${prefix}/models" />
   </export>
 </package>


### PR DESCRIPTION
This PR enables to load gazebo models without additional environment variable setting (such as GAZEBO_MODEL_PATH).
 
The following error occurs without this PR.
```bash
$ roslaunch nextage_gazebo nextage_world.launch
...

$ roslaunch nextage_ros_bridge ar_headcamera.launch sim:=true
...
Warning [ModelDatabase.cc:334] Getting models from[http://gazebosim.org/models/]. This may take a few seconds.
Msg Waiting for model database update to complete...
Error [ModelDatabase.cc:407] Unable to download model[model://MarkerBox-60mm/meshes/MarkerBox-60mm_Mesh.dae]
Error [SystemPaths.cc:367] File or path does not exist[""]
Error [Visual.cc:2133] No mesh specified
Error [ModelDatabase.cc:407] Unable to download model[model://MarkerBox-60mm/meshes/MarkerBox-60mm_Mesh.dae]
Error [SystemPaths.cc:367] File or path does not exist[""]
Error [Visual.cc:2133] No mesh specified
```