### PR TITLE
Add gazebo world for non-NVIDIA GPU

### DIFF
--- a/nextage_gazebo/launch/nextage_world.launch
+++ b/nextage_gazebo/launch/nextage_world.launch
@@ -52,7 +52,7 @@
 
 
   <!-- Load universal robotic description format (URDF) -->
-  <arg name="model" value="$(find nextage_description)/urdf/nxo_gz.xacro" />
+  <arg name="model" default="$(find nextage_description)/urdf/nxo_gz.xacro" />
   <param name="robot_description" command="$(find xacro)/xacro.py '$(arg model)'" />
   <node pkg="gazebo_ros" type="spawn_model" name="urdf_spawner" respawn="false" output="screen"
         args="$(arg gzpose) -J LARM_JOINT2 -2.0 -J RARM_JOINT2 -2.0 -urdf -model NextageOpen -param robot_description" />

--- a/nextage_gazebo/worlds/empty_for_non_nvidia.world
+++ b/nextage_gazebo/worlds/empty_for_non_nvidia.world
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<sdf version="1.5">
+  <world name="default">
+    <!-- Disable shadow to make world bright -->
+    <!-- Without activating NVIDIA GPU, world is very dark on gazebo 9 (ROS melodic) -->
+    <!-- See https://github.com/tork-a/rtmros_nextage/issues/370 -->
+    <!-- See https://bitbucket.org/osrf/gazebo/issues/2623/no-shadows-and-sun-light-with-non-nvidia -->
+    <scene>
+      <shadows>false</shadows>
+    </scene>
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+    <!-- A ground plane -->
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+  </world>
+</sdf>


### PR DESCRIPTION
For #370 
```
roslaunch nextage_gazebo nextage_world.launch world_file:=`rospack find nextage_gazebo`/worlds/empty_for_non_nvidia.world
```
![Screenshot from 2020-04-17 23-33-21](https://user-images.githubusercontent.com/14994939/79580886-9f425c00-8104-11ea-824c-77f21bc9dee0.png)
Without activating NVIDIA GPU, world is very dark on gazebo 9 (melodic).
So this PR adds world in which shadow is disabled to make world bright.
See #370 and https://bitbucket.org/osrf/gazebo/issues/2623/no-shadows-and-sun-light-with-non-nvidia