### PR TITLE
mod nextage_gazebo CMakeLists.txt to install models

### DIFF
--- a/nextage_gazebo/CMakeLists.txt
+++ b/nextage_gazebo/CMakeLists.txt
@@ -19,7 +19,7 @@ install(PROGRAMS
 )
 
 ## Mark other files for installation (e.g. launch and bag files, etc.)
-install(DIRECTORY config launch test
+install(DIRECTORY config launch test models
    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
    USE_SOURCE_PERMISSIONS
 )


### PR DESCRIPTION
There was no models in nextage_gazebo debian package.