### PR TITLE
Add compressed-image-transport dependency

### DIFF
--- a/nextage_ros_bridge/package.xml
+++ b/nextage_ros_bridge/package.xml
@@ -26,6 +26,7 @@
   <run_depend>stereo_image_proc</run_depend>
   <run_depend>ueye_cam</run_depend>
   <run_depend>ar_track_alvar</run_depend>
+  <run_depend>compressed_image_transport</run_depend>
 
   <test_depend>rostest</test_depend>
   <export/>


### PR DESCRIPTION
We launch `nextage_ueye_stereo.lauch` on Nextage Open, but `/left/image_raw/compressed` is not published because compressed_image_transport is not installed on Nextage Open.
We need `compressed` because we want to execute some image processing outside Nextage Open.

So, we added dependency on compressed_image_transport to nextage_ros_bridge so that compressed_image_transport is installed to Nextage Open when nextage_ros_bridge is installed.

(cc: @pazeshun )